### PR TITLE
Fix outputting null key and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ offset, and the timestamp to output):
 a2V5,TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ=,1232155,1554210895
 ```
 
+If the key, the value or the timestamp is null, an empty string will be
+output instead:
+
+```
+,,,1554210895
+```
+
 ## Configuration
 
 [Here](https://kafka.apache.org/documentation/#connect_running) you can

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/KeyWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/KeyWriter.java
@@ -31,7 +31,9 @@ public final class KeyWriter implements OutputFieldWriter {
     /**
      * Takes the {@link SinkRecord}'s key as a byte array.
      *
-     * <p>This assumes the key <b>is</b> a byte array.
+     * <p>If the key is {@code null}, it outputs nothing.
+     *
+     * <p>If the key is not {@code null}, it assumes the key <b>is</b> a byte array.
      *
      * @param record the record to get the key from
      * @param outputStream the stream to write to
@@ -42,13 +44,17 @@ public final class KeyWriter implements OutputFieldWriter {
                       final OutputStream outputStream) throws IOException {
         Objects.requireNonNull(record);
         Objects.requireNonNull(record.keySchema());
-        Objects.requireNonNull(record.key());
         Objects.requireNonNull(outputStream);
 
         if (record.keySchema().type() != Schema.Type.BYTES) {
             final String msg = String.format("Record key schema type must be %s, %s given",
                     Schema.Type.BYTES, record.keySchema().type());
             throw new DataException(msg);
+        }
+
+        // Do nothing if the key is null.
+        if (record.key() == null) {
+            return;
         }
 
         if (!(record.key() instanceof byte[])) {

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/ValueWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/ValueWriter.java
@@ -31,7 +31,9 @@ public final class ValueWriter implements OutputFieldWriter {
     /**
      * Takes the {@link SinkRecord}'s value as a byte array.
      *
-     * <p>This assumes the value <b>is</b> a byte array.
+     * <p>If the value is {@code null}, it outputs nothing.
+     *
+     * <p>If the value is not {@code null}, it assumes the value <b>is</b> a byte array.
      *
      * @param record the record to get the value from
      * @param outputStream the stream to write to
@@ -42,13 +44,17 @@ public final class ValueWriter implements OutputFieldWriter {
                       final OutputStream outputStream) throws IOException {
         Objects.requireNonNull(record);
         Objects.requireNonNull(record.valueSchema());
-        Objects.requireNonNull(record.value());
         Objects.requireNonNull(outputStream);
 
         if (record.valueSchema().type() != Schema.Type.BYTES) {
             final String msg = String.format("Record value schema type must be %s, %s given",
                     Schema.Type.BYTES, record.valueSchema().type());
             throw new DataException(msg);
+        }
+
+        // Do nothing if the key is null.
+        if (record.value() == null) {
+            return;
         }
 
         if (!(record.value() instanceof byte[])) {


### PR DESCRIPTION
This commit fixes an NPE that used to occur when a record with null key or value was about to be written.

A test for checking this was also added.