### PR TITLE
Improve configuration definition

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/gcs/config/FixedSetRecommender.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/FixedSetRecommender.java
@@ -1,0 +1,52 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.*;
+
+/**
+ * A {@link ConfigDef.Recommender} that always supports only
+ * the predefined set of values. {@link #visible(String, Map)} is always {@code true}.
+ */
+class FixedSetRecommender implements ConfigDef.Recommender {
+
+    private final List<Object> supportedValues;
+
+    private FixedSetRecommender(final Collection<?> supportedValues) {
+        Objects.requireNonNull(supportedValues);
+        this.supportedValues = new ArrayList<>(supportedValues);
+    }
+
+    @Override
+    public List<Object> validValues(final String name, final Map<String, Object> parsedConfig) {
+        return Collections.unmodifiableList(supportedValues);
+    }
+
+    @Override
+    public boolean visible(final String name, final Map<String, Object> parsedConfig) {
+        return true;
+    }
+
+    static FixedSetRecommender ofSupportedValues(final Collection<?> supportedValues) {
+        Objects.requireNonNull(supportedValues);
+        return new FixedSetRecommender(supportedValues);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
@@ -29,19 +29,30 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class GcsSinkConfig extends AbstractConfig {
+    private static final String GROUP_GCS = "GCS";
     public static final String GCS_CREDENTIALS_PATH_CONFIG = "gcs.credentials.path";
     public static final String GCS_CREDENTIALS_JSON_CONFIG = "gcs.credentials.json";
     public static final String GCS_BUCKET_NAME_CONFIG = "gcs.bucket.name";
 
-    public static final String FILE_COMPRESSION_TYPE_CONFIG = "file.compression.type";
+    private static final String GROUP_FILE = "File";
     public static final String FILE_NAME_PREFIX_CONFIG = "file.name.prefix";
+    public static final String FILE_COMPRESSION_TYPE_CONFIG = "file.compression.type";
 
+    private static final String GROUP_FORMAT = "Format";
     public static final String FORMAT_OUTPUT_FIELDS_CONFIG = "format.output.fields";
 
     public static final String NAME_CONFIG = "name";
 
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
+        addGcsConfigGroup(configDef);
+        addFileConfigGroup(configDef);
+        addFormatConfigGroup(configDef);
+        return configDef;
+    }
+
+    private static void addGcsConfigGroup(final ConfigDef configDef) {
+        int gcsGroupCounter = 0;
         configDef.define(
                 GCS_CREDENTIALS_PATH_CONFIG,
                 ConfigDef.Type.STRING,
@@ -49,7 +60,11 @@ public final class GcsSinkConfig extends AbstractConfig {
                 ConfigDef.Importance.LOW,
                 "The path to a GCP credentials file. " +
                         "If not provided, the connector will try to detect the credentials automatically. " +
-                        "Cannot be set together with \"" + GCS_CREDENTIALS_JSON_CONFIG + "\""
+                        "Cannot be set together with \"" + GCS_CREDENTIALS_JSON_CONFIG + "\"",
+                GROUP_GCS,
+                gcsGroupCounter++,
+                ConfigDef.Width.NONE,
+                GCS_CREDENTIALS_PATH_CONFIG
         );
 
         configDef.define(
@@ -59,7 +74,11 @@ public final class GcsSinkConfig extends AbstractConfig {
                 ConfigDef.Importance.LOW,
                 "GCP credentials as a JSON string. " +
                         "If not provided, the connector will try to detect the credentials automatically. " +
-                        "Cannot be set together with \"" + GCS_CREDENTIALS_PATH_CONFIG + "\""
+                        "Cannot be set together with \"" + GCS_CREDENTIALS_PATH_CONFIG + "\"",
+                GROUP_GCS,
+                gcsGroupCounter++,
+                ConfigDef.Width.NONE,
+                GCS_CREDENTIALS_JSON_CONFIG
         );
 
         configDef.define(
@@ -68,9 +87,16 @@ public final class GcsSinkConfig extends AbstractConfig {
                 ConfigDef.NO_DEFAULT_VALUE,
                 new ConfigDef.NonEmptyString(),
                 ConfigDef.Importance.HIGH,
-                "The GCS bucket name to store output files in."
+                "The GCS bucket name to store output files in.",
+                GROUP_GCS,
+                gcsGroupCounter++,
+                ConfigDef.Width.NONE,
+                GCS_BUCKET_NAME_CONFIG
         );
+    }
 
+    private static void addFileConfigGroup(final ConfigDef configDef) {
+        int fileGroupCounter = 0;
         configDef.define(
                 FILE_NAME_PREFIX_CONFIG,
                 ConfigDef.Type.STRING,
@@ -92,7 +118,11 @@ public final class GcsSinkConfig extends AbstractConfig {
                     }
                 },
                 ConfigDef.Importance.MEDIUM,
-                "The prefix to be added to the name of each file put on GCS."
+                "The prefix to be added to the name of each file put on GCS.",
+                GROUP_FILE,
+                fileGroupCounter++,
+                ConfigDef.Width.NONE,
+                FILE_NAME_PREFIX_CONFIG
         );
 
         final String supportedCompressionTypes = CompressionType.names().stream()
@@ -116,8 +146,17 @@ public final class GcsSinkConfig extends AbstractConfig {
                 },
                 ConfigDef.Importance.MEDIUM,
                 "The compression type used for files put on GCS. " +
-                        "The supported values are: " + supportedCompressionTypes + "."
+                        "The supported values are: " + supportedCompressionTypes + ".",
+                GROUP_FILE,
+                fileGroupCounter++,
+                ConfigDef.Width.NONE,
+                FILE_COMPRESSION_TYPE_CONFIG,
+                FixedSetRecommender.ofSupportedValues(CompressionType.names())
         );
+    }
+
+    private static void addFormatConfigGroup(final ConfigDef configDef) {
+        int formatGroupCounter = 0;
 
         final String supportedOutputFields = OutputField.names().stream()
                 .map(f -> "'" + f + "'")
@@ -148,9 +187,13 @@ public final class GcsSinkConfig extends AbstractConfig {
                 },
                 ConfigDef.Importance.MEDIUM,
                 "Fields to put into output files. " +
-                        "The supported values are: " + supportedOutputFields + "."
+                        "The supported values are: " + supportedOutputFields + ".",
+                GROUP_FORMAT,
+                formatGroupCounter++,
+                ConfigDef.Width.NONE,
+                FORMAT_OUTPUT_FIELDS_CONFIG,
+                FixedSetRecommender.ofSupportedValues(OutputField.names())
         );
-        return configDef;
     }
 
     public GcsSinkConfig(final Map<String, String> properties) {

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -38,6 +38,9 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests {@link GcsSinkConfig} class.
+ */
 final class GcsSinkConfigTest {
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigValidationTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigValidationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+/**
+ * Tests {@link GcsSinkConfig}'s config definition.
+ */
+final class GcsSinkConfigValidationTest {
+
+    @Test
+    void recommendedValuesForCompression() {
+        final Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put("file.compression.type", "unknown");
+
+        final ConfigValue v = GcsSinkConfig.configDef().validate(connectorProps).stream()
+                .filter(x -> x.name().equals("file.compression.type"))
+                .findFirst()
+                .get();
+        assertIterableEquals(
+                CompressionType.names(),
+                v.recommendedValues()
+        );
+    }
+
+    @Test
+    void recommendedValuesForFields() {
+        final Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put("format.output.fields", "unknown");
+
+        final ConfigValue v = GcsSinkConfig.configDef().validate(connectorProps).stream()
+                .filter(x -> x.name().equals("format.output.fields"))
+                .findFirst()
+                .get();
+        assertIterableEquals(
+                OutputField.names(),
+                v.recommendedValues()
+        );
+    }
+}


### PR DESCRIPTION
This commit improves the configuration definition, namely:
- introduce groups for configurations ('GCS', 'File', 'Format');
- adds recommended value for compression types and output fields.