### PR TITLE
GH-9 Allow to output a limited number of records per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ output instead:
 ,,,1554210895
 ```
 
+It is possible to control the number of records to be put in a
+particular output file by setting `file.max.records`. By default, it is
+`0`, which is interpreted as "unlimited".
+
 ## Configuration
 
 [Here](https://kafka.apache.org/documentation/#connect_running) you can

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
@@ -37,6 +37,7 @@ public final class GcsSinkConfig extends AbstractConfig {
     private static final String GROUP_FILE = "File";
     public static final String FILE_NAME_PREFIX_CONFIG = "file.name.prefix";
     public static final String FILE_COMPRESSION_TYPE_CONFIG = "file.compression.type";
+    public static final String FILE_MAX_RECORDS = "file.max.records";
 
     private static final String GROUP_FORMAT = "Format";
     public static final String FORMAT_OUTPUT_FIELDS_CONFIG = "format.output.fields";
@@ -153,6 +154,31 @@ public final class GcsSinkConfig extends AbstractConfig {
                 FILE_COMPRESSION_TYPE_CONFIG,
                 FixedSetRecommender.ofSupportedValues(CompressionType.names())
         );
+
+        configDef.define(
+                FILE_MAX_RECORDS,
+                ConfigDef.Type.INT,
+                0,
+                new ConfigDef.Validator() {
+                    @Override
+                    public void ensureValid(final String name, final Object value) {
+                        assert value instanceof Integer;
+                        if ((Integer) value < 0) {
+                            throw new ConfigException(
+                                    FILE_MAX_RECORDS, value,
+                                    "must be a non-negative integer number");
+                        }
+                    }
+                },
+                ConfigDef.Importance.MEDIUM,
+                "The maximum number of records to put in a single file. " +
+                        "Must be a non-negative integer number. " +
+                        "0 is interpreted as \"unlimited\", which is the default.",
+                GROUP_FILE,
+                fileGroupCounter++,
+                ConfigDef.Width.SHORT,
+                FILE_MAX_RECORDS
+        );
     }
 
     private static void addFormatConfigGroup(final ConfigDef configDef) {
@@ -242,5 +268,13 @@ public final class GcsSinkConfig extends AbstractConfig {
 
     public final String getConnectorName() {
         return originalsStrings().get(NAME_CONFIG);
+    }
+
+    public final boolean isMaxRecordPerFileLimited() {
+        return getMaxRecordsPerFile() > 0;
+    }
+
+    public final int getMaxRecordsPerFile() {
+        return getInt(FILE_MAX_RECORDS);
     }
 }

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -252,4 +252,34 @@ final class GcsSinkConfigTest {
                 "cannot start with '.well-known/acme-challenge'",
                 t.getMessage());
     }
+
+    @Test
+    void maxRecordsPerFileNotSet() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("gcs.bucket.name", "test-bucket");
+        final GcsSinkConfig config = new GcsSinkConfig(properties);
+        assertEquals(0, config.getMaxRecordsPerFile());
+    }
+
+    @Test
+    void maxRecordsPerFileSetCorrect() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("gcs.bucket.name", "test-bucket");
+        properties.put("file.max.records", "42");
+        final GcsSinkConfig config = new GcsSinkConfig(properties);
+        assertEquals(42, config.getMaxRecordsPerFile());
+    }
+
+    @Test
+    void maxRecordsPerFileSetIncorrect() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("gcs.bucket.name", "test-bucket");
+        properties.put("file.max.records", "-42");
+        final Throwable t = assertThrows(
+                ConfigException.class,
+                () -> new GcsSinkConfig(properties));
+        assertEquals("Invalid value -42 for configuration file.max.records: " +
+                        "must be a non-negative integer number",
+                t.getMessage());
+    }
 }


### PR DESCRIPTION
This commit makes it possible to limit the number of records to be put
in a single output file by setting `file.max.records`.

Closes #9 