### PR TITLE
GH-12 Allow to disable Base64 encoding of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ For example, if we output `key,value,offset,timestamp`, a record line might look
 a2V5,TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ=,1232155,1554210895
 ```
 
+It is possible to control the encoding of the `value` field by setting
+`format.output.fields.value.encoding` to `base64` or `none`.
+
 If the key, the value or the timestamp is null, an empty string will be
 output instead:
 

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/IntegrationTest.java
@@ -246,11 +246,11 @@ final class IntegrationTest {
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
         final Map<String, String> expectedBlobsAndContent = new HashMap<>();
-        expectedBlobsAndContent.put(getBlobName(0, 0, false), "value-0\n");
-        expectedBlobsAndContent.put(getBlobName(0, 1, false), "value-1\n");
-        expectedBlobsAndContent.put(getBlobName(0, 2, false), "value-2\n");
-        expectedBlobsAndContent.put(getBlobName(1, 0, false), "value-3\n");
-        expectedBlobsAndContent.put(getBlobName(3, 0, false), "value-4\n");
+        expectedBlobsAndContent.put(getBlobName(0, 0, false), "value-0");
+        expectedBlobsAndContent.put(getBlobName(0, 1, false), "value-1");
+        expectedBlobsAndContent.put(getBlobName(0, 2, false), "value-2");
+        expectedBlobsAndContent.put(getBlobName(1, 0, false), "value-3");
+        expectedBlobsAndContent.put(getBlobName(3, 0, false), "value-4");
         final List<String> expectedBlobsNames = expectedBlobsAndContent.keySet().stream().sorted().collect(Collectors.toList());
         assertIterableEquals(expectedBlobsNames, testBucketAccessor.getBlobNames());
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
@@ -127,9 +127,10 @@ public final class GcsSinkTask extends SinkTask {
             // Don't group these two tries,
             // because the internal one must be closed before writing to GCS.
             try (final OutputStream compressedStream = getCompressedStream(baos)) {
-                for (final SinkRecord record : chunk) {
-                    outputWriter.writeRecord(record, compressedStream);
+                for (int i = 0; i < chunk.size() - 1; i++) {
+                    outputWriter.writeRecord(chunk.get(i), compressedStream);
                 }
+                outputWriter.writeLastRecord(chunk.get(chunk.size() - 1), compressedStream);
             }
 
             storage.create(blob, baos.toByteArray());

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/OutputField.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/OutputField.java
@@ -18,44 +18,43 @@
 
 package io.aiven.kafka.connect.gcs.config;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import com.google.common.base.Objects;
 
-public enum OutputField {
-    KEY("key"),
-    VALUE("value"),
-    OFFSET("offset"),
-    TIMESTAMP("timestamp");
+public class OutputField {
+    private OutputFieldType fieldType;
+    private OutputFieldEncodingType encodingType;
 
-    public final String name;
-
-    OutputField(final String name) {
-        this.name = name;
+    public OutputField(final OutputFieldType fieldType, final OutputFieldEncodingType encodingType) {
+        this.fieldType = fieldType;
+        this.encodingType = encodingType;
     }
 
-    public static OutputField forName(final String name) {
-        Objects.requireNonNull(name);
+    public OutputFieldType getFieldType() {
+        return fieldType;
+    }
 
-        if (KEY.name.equalsIgnoreCase(name)) {
-            return KEY;
-        } else if (VALUE.name.equalsIgnoreCase(name)) {
-            return VALUE;
-        } else if (OFFSET.name.equalsIgnoreCase(name)) {
-            return OFFSET;
-        } else if (TIMESTAMP.name.equalsIgnoreCase(name)) {
-            return TIMESTAMP;
-        } else {
-            throw new IllegalArgumentException("Unknown output field: " + name);
+    public OutputFieldEncodingType getEncodingType() {
+        return encodingType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(fieldType, encodingType);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
         }
-    }
 
-    public static boolean isValidName(final String name) {
-        return names().contains(name.toLowerCase());
-    }
+        if (!(obj instanceof OutputField)) {
+            return false;
+        }
 
-    public static Collection<String> names() {
-        return Arrays.stream(values()).map(v -> v.name).collect(Collectors.toList());
+        final OutputField that = (OutputField) obj;
+
+        return Objects.equal(this.fieldType, that.fieldType)
+                && Objects.equal(this.encodingType, that.encodingType);
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/OutputFieldEncodingType.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/OutputFieldEncodingType.java
@@ -1,0 +1,55 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public enum OutputFieldEncodingType {
+    NONE("none"),
+    BASE64("base64");
+
+    public final String name;
+
+    OutputFieldEncodingType(final String name) {
+        this.name = name;
+    }
+
+    public static OutputFieldEncodingType forName(final String name) {
+        Objects.requireNonNull(name);
+
+        if (NONE.name.equalsIgnoreCase(name)) {
+            return NONE;
+        } else if (BASE64.name.equalsIgnoreCase(name)) {
+            return BASE64;
+        } else {
+            throw new IllegalArgumentException("Unknown output field encoding type: " + name);
+        }
+    }
+
+    public static boolean isValidName(final String name) {
+        return names().contains(name.toLowerCase());
+    }
+
+    public static Collection<String> names() {
+        return Arrays.stream(values()).map(v -> v.name).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/OutputFieldType.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/OutputFieldType.java
@@ -1,0 +1,61 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public enum OutputFieldType {
+    KEY("key"),
+    VALUE("value"),
+    OFFSET("offset"),
+    TIMESTAMP("timestamp");
+
+    public final String name;
+
+    OutputFieldType(final String name) {
+        this.name = name;
+    }
+
+    public static OutputFieldType forName(final String name) {
+        Objects.requireNonNull(name);
+
+        if (KEY.name.equalsIgnoreCase(name)) {
+            return KEY;
+        } else if (VALUE.name.equalsIgnoreCase(name)) {
+            return VALUE;
+        } else if (OFFSET.name.equalsIgnoreCase(name)) {
+            return OFFSET;
+        } else if (TIMESTAMP.name.equalsIgnoreCase(name)) {
+            return TIMESTAMP;
+        } else {
+            throw new IllegalArgumentException("Unknown output field: " + name);
+        }
+    }
+
+    public static boolean isValidName(final String name) {
+        return names().contains(name.toLowerCase());
+    }
+
+    public static Collection<String> names() {
+        return Arrays.stream(values()).map(v -> v.name).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/AbstractValueWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/AbstractValueWriter.java
@@ -24,10 +24,9 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Base64;
 import java.util.Objects;
 
-public final class ValueWriter implements OutputFieldWriter {
+public abstract class AbstractValueWriter implements OutputFieldWriter {
     /**
      * Takes the {@link SinkRecord}'s value as a byte array.
      *
@@ -61,6 +60,8 @@ public final class ValueWriter implements OutputFieldWriter {
             throw new DataException("Value is not a byte array");
         }
 
-        outputStream.write(Base64.getEncoder().encode((byte[]) record.value()));
+        outputStream.write(getOutputBytes((byte[]) record.value()));
     }
+
+    protected abstract byte[] getOutputBytes(final byte[] value);
 }

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/Base64ValueWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/Base64ValueWriter.java
@@ -1,0 +1,28 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.output;
+
+import java.util.Base64;
+
+public class Base64ValueWriter extends AbstractValueWriter {
+    @Override
+    protected byte[] getOutputBytes(final byte[] value) {
+        return Base64.getEncoder().encode(value);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/OutputWriter.java
@@ -59,13 +59,24 @@ public final class OutputWriter {
             Objects.requireNonNull(fields);
 
             for (final OutputField field : fields) {
-                switch (field) {
+                switch (field.getFieldType()) {
                     case KEY:
                         writers.add(new KeyWriter());
                         break;
 
                     case VALUE:
-                        writers.add(new ValueWriter());
+                        switch (field.getEncodingType()) {
+                            case NONE:
+                                writers.add(new PlainValueWriter());
+                                break;
+
+                            case BASE64:
+                                writers.add(new Base64ValueWriter());
+                                break;
+
+                            default:
+                                throw new ConnectException("Unknown output field encoding type " + field.getEncodingType());
+                        }
                         break;
 
                     case OFFSET:
@@ -77,7 +88,7 @@ public final class OutputWriter {
                         break;
 
                     default:
-                        throw new ConnectException("Unknown output field " + field);
+                        throw new ConnectException("Unknown output field type " + field);
                 }
             }
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/OutputWriter.java
@@ -42,14 +42,25 @@ public final class OutputWriter {
                             final OutputStream outputStream) throws IOException {
         Objects.requireNonNull(record);
         Objects.requireNonNull(outputStream);
+        writeFields(record, outputStream);
+        outputStream.write(RECORD_SEPARATOR);
+    }
 
+    public void writeLastRecord(final SinkRecord record,
+                                final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record);
+        Objects.requireNonNull(outputStream);
+        writeFields(record, outputStream);
+    }
+
+    private void writeFields(final SinkRecord record,
+                             final OutputStream outputStream) throws IOException {
         final Iterator<OutputFieldWriter> writerIter = writers.iterator();
         writerIter.next().write(record, outputStream);
         while (writerIter.hasNext()) {
             outputStream.write(FIELD_SEPARATOR);
             writerIter.next().write(record, outputStream);
         }
-        outputStream.write(RECORD_SEPARATOR);
     }
 
     public static final class Builder {

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/PlainValueWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/PlainValueWriter.java
@@ -1,0 +1,26 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.output;
+
+public class PlainValueWriter extends AbstractValueWriter {
+    @Override
+    protected byte[] getOutputBytes(final byte[] value) {
+        return value;
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
@@ -112,6 +112,42 @@ final class GcsSinkTaskTest {
     }
 
     @Test
+    final void basicValuesPlain() {
+        properties.put(GcsSinkConfig.FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG, "none");
+        final GcsSinkTask task = new GcsSinkTask(properties, storage);
+
+        task.put(basicRecords);
+        task.flush(null);
+
+        assertAll(
+                () -> assertIterableEquals(
+                        Lists.newArrayList("topic0-0-10", "topic0-1-20", "topic0-2-50", "topic1-0-30", "topic1-1-40"),
+                        testBucketAccessor.getBlobNames()
+                ),
+                () -> assertIterableEquals(
+                        Lists.newArrayList(Arrays.asList("value0"), Arrays.asList("value5")),
+                        readSplittedAndDecodedLinesFromBlob("topic0-0-10", false)
+                ),
+                () -> assertIterableEquals(
+                        Lists.newArrayList(Arrays.asList("value1"), Arrays.asList("value6")),
+                        readSplittedAndDecodedLinesFromBlob("topic0-1-20", false)
+                ),
+                () -> assertIterableEquals(
+                        Lists.newArrayList(Arrays.asList("value4"), Arrays.asList("value9")),
+                        readSplittedAndDecodedLinesFromBlob("topic0-2-50", false)
+                ),
+                () -> assertIterableEquals(
+                        Lists.newArrayList(Arrays.asList("value2"), Arrays.asList("value7")),
+                        readSplittedAndDecodedLinesFromBlob("topic1-0-30", false)
+                ),
+                () -> assertIterableEquals(
+                        Lists.newArrayList(Arrays.asList("value3"), Arrays.asList("value8")),
+                        readSplittedAndDecodedLinesFromBlob("topic1-1-40", false)
+                )
+        );
+    }
+
+    @Test
     final void compression() {
         properties.put(GcsSinkConfig.FILE_COMPRESSION_TYPE_CONFIG, "gzip");
         final GcsSinkTask task = new GcsSinkTask(properties, storage);

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -72,7 +72,7 @@ final class GcsSinkConfigTest {
                 () -> assertEquals("test-bucket", config.getBucketName()),
                 () -> assertEquals(CompressionType.NONE, config.getCompressionType()),
                 () -> assertEquals("", config.getPrefix()),
-                () -> assertIterableEquals(Collections.singleton(OutputField.VALUE), config.getOutputFields())
+                () -> assertIterableEquals(Collections.singleton(new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.BASE64)), config.getOutputFields())
         );
     }
 
@@ -85,19 +85,23 @@ final class GcsSinkConfigTest {
         properties.put("gcs.bucket.name", "test-bucket");
         properties.put("file.compression.type", "gzip");
         properties.put("file.name.prefix", "test-prefix");
+        properties.put("file.max.records", "42");
         properties.put("format.output.fields", "key,value,offset,timestamp");
+        properties.put("format.output.fields.value.encoding", "base64");
 
         final GcsSinkConfig config = new GcsSinkConfig(properties);
         assertAll(
                 () -> assertDoesNotThrow(() -> config.getCredentials()),
                 () -> assertEquals("test-bucket", config.getBucketName()),
                 () -> assertEquals(CompressionType.GZIP, config.getCompressionType()),
+                () -> assertTrue(config.isMaxRecordPerFileLimited()),
+                () -> assertEquals(42, config.getMaxRecordsPerFile()),
                 () -> assertEquals("test-prefix", config.getPrefix()),
                 () -> assertIterableEquals(Arrays.asList(
-                        OutputField.KEY,
-                        OutputField.VALUE,
-                        OutputField.OFFSET,
-                        OutputField.TIMESTAMP), config.getOutputFields())
+                        new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE),
+                        new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.BASE64),
+                        new OutputField(OutputFieldType.OFFSET, OutputFieldEncodingType.NONE),
+                        new OutputField(OutputFieldType.TIMESTAMP, OutputFieldEncodingType.NONE)), config.getOutputFields())
         );
     }
 

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigValidationTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigValidationTest.java
@@ -56,7 +56,7 @@ final class GcsSinkConfigValidationTest {
                 .findFirst()
                 .get();
         assertIterableEquals(
-                OutputField.names(),
+                OutputFieldType.names(),
                 v.recommendedValues()
         );
     }

--- a/src/test/java/io/aiven/kafka/connect/gcs/testutils/BlobAccessor.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/testutils/BlobAccessor.java
@@ -49,6 +49,11 @@ public final class BlobAccessor {
         this.compressed = compressed;
     }
 
+    public final String readStringContent() throws IOException {
+        final byte[] blobBytes = storage.readAllBytes(bucketName, blobName);
+        return new String(blobBytes);
+    }
+
     public final List<String> readLines() throws IOException {
         final byte[] blobBytes = storage.readAllBytes(bucketName, blobName);
         try (final ByteArrayInputStream bais = new ByteArrayInputStream(blobBytes);


### PR DESCRIPTION
This PR allows to output `value` field without Base64 encoding
by setting `format.output.fields.value.encoding` to `none`.

Also, it makes `OutputWriter` treat the last record in a chunk
differently by not outputting the record separator after it. This will
allow files in one-file-per-record use case to have perfect copy of
record values without extra `\n` in the end.