### PR TITLE
GH-14 Externalize logic of grouping records into files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:1.7.25"
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.1'
+    testImplementation 'org.hamcrest:hamcrest:2.1'
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     testImplementation 'com.google.cloud:google-cloud-nio:0.84.0-alpha'
     testRuntime 'ch.qos.logback:logback-classic:1.2.3'

--- a/src/main/java/io/aiven/kafka/connect/gcs/RecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/RecordGrouper.java
@@ -1,0 +1,44 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The interface for classes that associates {@link SinkRecord}s with files by some criteria.
+ */
+interface RecordGrouper {
+    /**
+     * Associate the record with the appropriate file.
+     */
+    void put(SinkRecord record);
+
+    /**
+     * Clear all records.
+     */
+    void clear();
+
+    /**
+     * Get all records associated with files, grouped by the file name.
+     */
+    Map<String, List<SinkRecord>> records();
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/TopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/TopicPartitionRecordGrouper.java
@@ -1,0 +1,120 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import io.aiven.kafka.connect.gcs.config.FilenameTemplateVariable;
+import io.aiven.kafka.connect.gcs.templating.Template;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.*;
+
+/**
+ * A {@link RecordGrouper} that groups record by topic and partition.
+ *
+ * <p>The class requires a filename template with {@code topic}, {@code partition},
+ * and {@code start_offset} variables declared.
+ *
+ * <p>The class supports limited and unlimited number of records in files.
+ */
+final class TopicPartitionRecordGrouper implements RecordGrouper {
+    private static final List<String> EXPECTED_VARIABLE_LIST = new ArrayList<>();
+    static {
+        EXPECTED_VARIABLE_LIST.add(FilenameTemplateVariable.TOPIC.name);
+        EXPECTED_VARIABLE_LIST.add(FilenameTemplateVariable.PARTITION.name);
+        EXPECTED_VARIABLE_LIST.add(FilenameTemplateVariable.START_OFFSET.name);
+    }
+    private static final Set<String> EXPECTED_VARIABLE_SET = new HashSet<>(EXPECTED_VARIABLE_LIST);
+
+    private final Template filenameTemplate;
+    private final Integer maxRecordsPerFile;
+
+    private final Map<TopicPartition, SinkRecord> currentHeadRecords = new HashMap<>();
+    private final Map<String, List<SinkRecord>> fileBuffers = new HashMap<>();
+
+    /**
+     * A constructor.
+     *
+     * @param filenameTemplate the filename template.
+     * @param maxRecordsPerFile the maximum number of records per file ({@code null} for unlimited).
+     */
+    public TopicPartitionRecordGrouper(final Template filenameTemplate, final Integer maxRecordsPerFile) {
+        Objects.requireNonNull(filenameTemplate);
+
+        if (!EXPECTED_VARIABLE_SET.equals(new HashSet<>(filenameTemplate.getVariables()))) {
+            throw new IllegalArgumentException(
+                    "filenameTemplate must have set of variables {"
+                            + String.join(",", EXPECTED_VARIABLE_LIST)
+                            + "}, but {"
+                            + String.join(",", filenameTemplate.getVariables())
+                            + "} was given"
+                    );
+        }
+
+        this.filenameTemplate = filenameTemplate;
+        this.maxRecordsPerFile = maxRecordsPerFile;
+    }
+
+    @Override
+    public void put(final SinkRecord record) {
+        Objects.requireNonNull(record);
+
+        final TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
+        final SinkRecord currentHeadRecord = currentHeadRecords.computeIfAbsent(tp, ignored -> record);
+        final String filename = renderFilename(tp, currentHeadRecord);
+
+        if (shouldCreateNewFile(filename)) {
+            // Create new file using this record as the head record.
+            currentHeadRecords.put(tp, record);
+            final String newFilename = renderFilename(tp, record);
+            fileBuffers.computeIfAbsent(newFilename, ignored -> new ArrayList<>()).add(record);
+        } else {
+            fileBuffers.computeIfAbsent(filename, ignored -> new ArrayList<>()).add(record);
+        }
+    }
+
+    private String renderFilename(final TopicPartition tp, final SinkRecord headRecord) {
+        return filenameTemplate.instance()
+                .bindVariable(FilenameTemplateVariable.TOPIC.name, tp::topic)
+                .bindVariable(FilenameTemplateVariable.PARTITION.name, () -> Integer.toString(tp.partition()))
+                .bindVariable(FilenameTemplateVariable.START_OFFSET.name, () -> Long.toString(headRecord.kafkaOffset()))
+                .render();
+    }
+
+    private boolean shouldCreateNewFile(final String filename) {
+        final boolean unlimited = maxRecordsPerFile == null;
+        if (unlimited) {
+            return false;
+        } else {
+            final List<SinkRecord> buffer = fileBuffers.get(filename);
+            return buffer == null || buffer.size() >= maxRecordsPerFile;
+        }
+    }
+
+    @Override
+    public void clear() {
+        currentHeadRecords.clear();
+        fileBuffers.clear();
+    }
+
+    @Override
+    public Map<String, List<SinkRecord>> records() {
+        return Collections.unmodifiableMap(fileBuffers);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
@@ -330,10 +330,6 @@ public final class GcsSinkConfig extends AbstractConfig {
         return originalsStrings().get(NAME_CONFIG);
     }
 
-    public final boolean isMaxRecordPerFileLimited() {
-        return getMaxRecordsPerFile() > 0;
-    }
-
     public final int getMaxRecordsPerFile() {
         return getInt(FILE_MAX_RECORDS);
     }

--- a/src/test/java/io/aiven/kafka/connect/gcs/TopicPartitionRecordGrouperTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/TopicPartitionRecordGrouperTest.java
@@ -1,0 +1,183 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import io.aiven.kafka.connect.gcs.templating.Template;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class TopicPartitionRecordGrouperTest {
+
+    private static final SinkRecord T0P0R0 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 0);
+    private static final SinkRecord T0P0R1 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "some_key", null, null, 1);
+    private static final SinkRecord T0P0R2 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 2);
+    private static final SinkRecord T0P0R3 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 3);
+    private static final SinkRecord T0P0R4 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "some_key", null, null, 4);
+    private static final SinkRecord T0P0R5 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "some_key", null, null, 5);
+
+    private static final SinkRecord T0P1R0 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 10);
+    private static final SinkRecord T0P1R1 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 11);
+    private static final SinkRecord T0P1R2 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 12);
+    private static final SinkRecord T0P1R3 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, "some_key", null, null, 13);
+
+    private static final SinkRecord T1P1R0 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, "some_key", null, null, 1000);
+    private static final SinkRecord T1P1R1 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 1001);
+    private static final SinkRecord T1P1R2 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 1002);
+    private static final SinkRecord T1P1R3 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, "some_key", null, null, 1003);
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "{{topic}}", "{{partition}}", "{{start_offset}}",
+            "{{topic}}-{{partition}}", "{{topic}}-{{start_offset}}", "{{partition}}-{{start_offset}}",
+            "{{topic}}-{{partition}}-{{start_offset}}-{{unknown}}"
+    })
+    final void incorrectFilenameTemplates(final String template) {
+        final Template filenameTemplate = new Template(template);
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new TopicPartitionRecordGrouper(filenameTemplate, null));
+        assertEquals(
+                "filenameTemplate must have set of variables {topic,partition,start_offset}, but {"
+                + String.join(",", filenameTemplate.getVariables())
+                + "} was given",
+                ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(ints = 10)
+    final void empty(final Integer maxRecordsPerFile) {
+        final Template filenameTemplate = new Template("{{topic}}-{{partition}}-{{start_offset}}");
+        final TopicPartitionRecordGrouper fileGrouper = new TopicPartitionRecordGrouper(filenameTemplate, maxRecordsPerFile);
+        assertThat(fileGrouper.records(), anEmptyMap());
+    }
+
+    @Test
+    final void unlimited() {
+        final Template filenameTemplate = new Template("{{topic}}-{{partition}}-{{start_offset}}");
+        final TopicPartitionRecordGrouper fileGrouper = new TopicPartitionRecordGrouper(filenameTemplate, null);
+
+        fileGrouper.put(T0P1R0);
+        fileGrouper.put(T0P0R0);
+        fileGrouper.put(T0P1R1);
+        fileGrouper.put(T0P0R1);
+        fileGrouper.put(T0P0R2);
+        fileGrouper.put(T0P1R2);
+        fileGrouper.put(T0P0R3);
+        fileGrouper.put(T1P1R0);
+        fileGrouper.put(T1P1R1);
+        fileGrouper.put(T0P0R4);
+        fileGrouper.put(T1P1R2);
+        fileGrouper.put(T1P1R3);
+        fileGrouper.put(T0P0R5);
+        fileGrouper.put(T0P1R3);
+
+        final Map<String, List<SinkRecord>> records = fileGrouper.records();
+        assertThat(records.keySet(), containsInAnyOrder("topic0-0-0", "topic0-1-10", "topic1-0-1000"));
+        assertThat(records.get("topic0-0-0"),
+                contains(T0P0R0, T0P0R1, T0P0R2, T0P0R3, T0P0R4, T0P0R5));
+        assertThat(records.get("topic0-1-10"),
+                contains(T0P1R0, T0P1R1, T0P1R2, T0P1R3));
+        assertThat(records.get("topic1-0-1000"),
+                contains(T1P1R0, T1P1R1, T1P1R2, T1P1R3));
+    }
+
+    @Test
+    final void limited() {
+        final Template filenameTemplate = new Template("{{topic}}-{{partition}}-{{start_offset}}");
+        final TopicPartitionRecordGrouper fileGrouper = new TopicPartitionRecordGrouper(filenameTemplate, 2);
+
+        fileGrouper.put(T0P1R0);
+        fileGrouper.put(T0P0R0);
+        fileGrouper.put(T0P1R1);
+        fileGrouper.put(T0P0R1);
+        fileGrouper.put(T0P0R2);
+        fileGrouper.put(T0P1R2);
+        fileGrouper.put(T0P0R3);
+        fileGrouper.put(T1P1R0);
+        fileGrouper.put(T1P1R1);
+        fileGrouper.put(T0P0R4);
+        fileGrouper.put(T1P1R2);
+        fileGrouper.put(T1P1R3);
+        fileGrouper.put(T0P0R5);
+        fileGrouper.put(T0P1R3);
+
+        final Map<String, List<SinkRecord>> records = fileGrouper.records();
+        assertThat(records.keySet(),
+                containsInAnyOrder("topic0-0-0", "topic0-0-2", "topic0-0-4", "topic0-1-10", "topic0-1-12", "topic1-0-1000", "topic1-0-1002"));
+        assertThat(records.get("topic0-0-0"),
+                contains(T0P0R0, T0P0R1));
+        assertThat(records.get("topic0-0-2"),
+                contains(T0P0R2, T0P0R3));
+        assertThat(records.get("topic0-0-4"),
+                contains(T0P0R4, T0P0R5));
+        assertThat(records.get("topic0-1-10"),
+                contains(T0P1R0, T0P1R1));
+        assertThat(records.get("topic0-1-12"),
+                contains(T0P1R2, T0P1R3));
+        assertThat(records.get("topic1-0-1000"),
+                contains(T1P1R0, T1P1R1));
+        assertThat(records.get("topic1-0-1002"),
+                contains(T1P1R2, T1P1R3));
+    }
+
+    @Test
+    final void clear() {
+        final Template filenameTemplate = new Template("{{topic}}-{{partition}}-{{start_offset}}");
+        final TopicPartitionRecordGrouper fileGrouper = new TopicPartitionRecordGrouper(filenameTemplate, null);
+
+        fileGrouper.put(T0P1R0);
+        fileGrouper.put(T0P0R0);
+        fileGrouper.put(T0P1R1);
+        fileGrouper.put(T0P0R1);
+        fileGrouper.put(T0P0R2);
+        fileGrouper.put(T0P1R2);
+        fileGrouper.put(T0P0R3);
+        fileGrouper.put(T0P1R3);
+
+        fileGrouper.clear();
+        assertThat(fileGrouper.records(), anEmptyMap());
+
+        fileGrouper.put(T1P1R0);
+        fileGrouper.put(T1P1R1);
+        fileGrouper.put(T0P0R4);
+        fileGrouper.put(T1P1R2);
+        fileGrouper.put(T1P1R3);
+        fileGrouper.put(T0P0R5);
+
+        final Map<String, List<SinkRecord>> records = fileGrouper.records();
+        assertThat(records.keySet(), containsInAnyOrder("topic0-0-4", "topic1-0-1000"));
+        assertThat(records.get("topic0-0-4"),
+                contains(T0P0R4, T0P0R5));
+        assertThat(records.get("topic1-0-1000"),
+                contains(T1P1R0, T1P1R1, T1P1R2, T1P1R3));
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -102,7 +102,6 @@ final class GcsSinkConfigTest {
                 () -> assertDoesNotThrow(() -> config.getCredentials()),
                 () -> assertEquals("test-bucket", config.getBucketName()),
                 () -> assertEquals(CompressionType.GZIP, config.getCompressionType()),
-                () -> assertTrue(config.isMaxRecordPerFileLimited()),
                 () -> assertEquals(42, config.getMaxRecordsPerFile()),
                 () -> assertEquals("test-prefix", config.getPrefix()),
                 () -> assertEquals("a-b-c.gz",


### PR DESCRIPTION
This commit introduces `RecordGrouper` interface and an implementation
`TopicPartitionRecordGrouper` that encapsulates the logic of grouping
`SinkRecord`s into files by topic and partition currently implemented in
`GcsSinkTask`. Also, the commit adds some tests for it.

The purpose of this change is to enable adding new grouping logics like
by records' key.