### PR TITLE
GH-14 Add support for `{{key}}` file name template

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/gcs/KeyRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/KeyRecordGrouper.java
@@ -1,0 +1,111 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import io.aiven.kafka.connect.gcs.config.FilenameTemplateVariable;
+import io.aiven.kafka.connect.gcs.templating.Template;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.*;
+
+/**
+ * A {@link RecordGrouper} that groups records by key.
+ *
+ * <p>The class requires a filename template with {@code key} variable declared.
+ *
+ * <p>The class supports one record per file.
+ */
+final class KeyRecordGrouper implements RecordGrouper {
+    private static final List<String> EXPECTED_VARIABLE_LIST = Arrays.asList(
+            FilenameTemplateVariable.KEY.name
+    );
+
+    private final Template filenameTemplate;
+
+    // One record pre file, but use List here for the compatibility with the interface.
+    private final Map<String, List<SinkRecord>> fileBuffers = new HashMap<>();
+
+    /**
+     * A constructor.
+     *
+     * @param filenameTemplate the filename template.
+     */
+    public KeyRecordGrouper(final Template filenameTemplate) {
+        Objects.requireNonNull(filenameTemplate);
+
+        if (!acceptsTemplate(filenameTemplate)) {
+            throw new IllegalArgumentException(
+                    "filenameTemplate must have set of variables {"
+                            + String.join(",", EXPECTED_VARIABLE_LIST)
+                            + "}, but {"
+                            + String.join(",", filenameTemplate.variables())
+                            + "} was given"
+                    );
+        }
+
+        this.filenameTemplate = filenameTemplate;
+    }
+
+    @Override
+    public void put(final SinkRecord record) {
+        Objects.requireNonNull(record);
+
+        final String filename = renderFilename(record);
+
+        fileBuffers.putIfAbsent(filename, new ArrayList<>());
+
+        // one record per file
+        final List<SinkRecord> records = fileBuffers.get(filename);
+        records.clear();
+        records.add(record);
+    }
+
+    private String renderFilename(final SinkRecord record) {
+        final String keyString;
+        if (record.key() == null) {
+            keyString = "null";
+        } else if (record.keySchema().type() == Schema.Type.STRING) {
+            keyString = (String) record.key();
+        } else {
+            keyString = record.key().toString();
+        }
+
+        return filenameTemplate.instance()
+                .bindVariable(FilenameTemplateVariable.KEY.name, () -> keyString)
+                .render();
+    }
+
+    @Override
+    public void clear() {
+        fileBuffers.clear();
+    }
+
+    @Override
+    public Map<String, List<SinkRecord>> records() {
+        return Collections.unmodifiableMap(fileBuffers);
+    }
+
+    /**
+     * Checks if the template is acceptable for this grouper.
+     */
+    static boolean acceptsTemplate(final Template filenameTemplate) {
+        return new HashSet<>(EXPECTED_VARIABLE_LIST).equals(filenameTemplate.variablesSet());
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateValidator.java
@@ -23,18 +23,26 @@ import io.aiven.kafka.connect.gcs.templating.Template;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 final class FilenameTemplateValidator implements ConfigDef.Validator {
 
     private final String configName;
 
-    private static final Set<String> SUPPORTED_VARIABLE_SET = Sets.newHashSet(
-            FilenameTemplateVariable.TOPIC.name,
-            FilenameTemplateVariable.PARTITION.name,
-            FilenameTemplateVariable.START_OFFSET.name
-    );
+    private static final List<Set<String>> SUPPORTED_VARIABLES_SETS = new ArrayList<>();
+    static {
+        SUPPORTED_VARIABLES_SETS.add(
+                Sets.newHashSet(FilenameTemplateVariable.TOPIC.name,
+                        FilenameTemplateVariable.PARTITION.name,
+                        FilenameTemplateVariable.START_OFFSET.name)
+        );
+        SUPPORTED_VARIABLES_SETS.add(
+                Sets.newHashSet(FilenameTemplateVariable.KEY.name)
+        );
+    }
 
     FilenameTemplateValidator(final String configName) {
         this.configName = configName;
@@ -56,11 +64,21 @@ final class FilenameTemplateValidator implements ConfigDef.Validator {
         }
 
         final Template template = new Template((String) value);
-        final Set<String> variablesInTemplate = new HashSet<>(template.getVariables());
-        if (!variablesInTemplate.equals(SUPPORTED_VARIABLE_SET)) {
+
+        boolean isVariableSetSupported = false;
+        for (final Set<String> supportedVariablesSet : SUPPORTED_VARIABLES_SETS) {
+            if (supportedVariablesSet.equals(template.variablesSet())) {
+                isVariableSetSupported = true;
+                break;
+            }
+        }
+        if (!isVariableSetSupported) {
+            final String supportedSetsStr = SUPPORTED_VARIABLES_SETS.stream()
+                    .map(set -> String.join(",", set))
+                    .collect(Collectors.joining("; "));
+
             throw new ConfigException(configName, value,
-                    "unsupported set of template variables, supported set is: "
-                            + String.join(", ", SUPPORTED_VARIABLE_SET));
+                    "unsupported set of template variables, supported sets are: " + supportedSetsStr);
         }
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateVariable.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateVariable.java
@@ -21,7 +21,8 @@ package io.aiven.kafka.connect.gcs.config;
 public enum FilenameTemplateVariable {
     TOPIC("topic"),
     PARTITION("partition"),
-    START_OFFSET("start_offset");
+    START_OFFSET("start_offset"),
+    KEY("key");
 
     public final String name;
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfig.java
@@ -19,6 +19,7 @@
 package io.aiven.kafka.connect.gcs.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableSet;
 import io.aiven.kafka.connect.gcs.gcs.GoogleCredentialsBuilder;
 import io.aiven.kafka.connect.gcs.templating.Template;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -286,6 +287,17 @@ public final class GcsSinkConfig extends AbstractConfig {
                     "\"%s\" and \"%s\" are mutually exclusive options, but both are set.",
                     GCS_CREDENTIALS_PATH_CONFIG, GCS_CREDENTIALS_JSON_CONFIG);
             throw new ConfigException(msg);
+        }
+
+        // Special checks for {{key}} filename template.
+        final Template filenameTemplate = getFilenameTemplate();
+        if (ImmutableSet.of(FilenameTemplateVariable.KEY.name).equals(filenameTemplate.variablesSet())) {
+            if (getMaxRecordsPerFile() > 1) {
+                final String msg = String.format("When %s is %s, %s must be either 1 or not set",
+                        FILE_NAME_TEMPLATE_CONFIG, filenameTemplate, FILE_MAX_RECORDS);
+                throw new ConfigException(msg);
+            }
+
         }
     }
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/output/KeyWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/output/KeyWriter.java
@@ -46,9 +46,10 @@ public final class KeyWriter implements OutputFieldWriter {
         Objects.requireNonNull(record.keySchema());
         Objects.requireNonNull(outputStream);
 
-        if (record.keySchema().type() != Schema.Type.BYTES) {
-            final String msg = String.format("Record key schema type must be %s, %s given",
-                    Schema.Type.BYTES, record.keySchema().type());
+        if (record.keySchema().type() != Schema.Type.BYTES
+                && record.keySchema().type() != Schema.Type.STRING) {
+            final String msg = String.format("Record key schema type must be %s or %s, %s given",
+                    Schema.Type.BYTES, Schema.Type.STRING, record.keySchema().type());
             throw new DataException(msg);
         }
 
@@ -57,10 +58,12 @@ public final class KeyWriter implements OutputFieldWriter {
             return;
         }
 
-        if (!(record.key() instanceof byte[])) {
-            throw new DataException("Key is not a byte array");
+        if (record.key() instanceof byte[]) {
+            outputStream.write(Base64.getEncoder().encode((byte[]) record.key()));
+        } else if (record.key() instanceof String) {
+            outputStream.write(Base64.getEncoder().encode(((String) record.key()).getBytes()));
+        } else {
+            throw new DataException("Key is not byte[] or String");
         }
-
-        outputStream.write(Base64.getEncoder().encode((byte[]) record.key()));
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/gcs/templating/Template.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/templating/Template.java
@@ -35,10 +35,14 @@ import java.util.regex.Pattern;
 public final class Template {
     private final static Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{\\s*([\\w_]+)\\s*}}"); // {{ var }}
 
+    private final String originalTemplateString;
+
     private final List<String> variables = new ArrayList<>();
     private final List<TemplatePart> templateParts = new ArrayList<>();
 
     public Template(final String template) {
+        this.originalTemplateString = template;
+
         final Matcher m = VARIABLE_PATTERN.matcher(template);
         int position = 0;
         while (m.find()) {
@@ -52,8 +56,12 @@ public final class Template {
         templateParts.add(new StaticTemplatePart(template.substring(position)));
     }
 
-    public final List<String> getVariables() {
+    public final List<String> variables() {
         return Collections.unmodifiableList(variables);
+    }
+
+    public final Set<String> variablesSet() {
+        return Collections.unmodifiableSet(new HashSet<>(variables));
     }
 
     public final Instance instance() {
@@ -78,6 +86,11 @@ public final class Template {
             this.variableName = variableName;
             this.originalPlaceholder = originalPlaceholder;
         }
+    }
+
+    @Override
+    public String toString() {
+        return originalTemplateString;
     }
 
     public class Instance {

--- a/src/test/java/io/aiven/kafka/connect/gcs/KeyRecordGrouperTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/KeyRecordGrouperTest.java
@@ -1,0 +1,133 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import io.aiven.kafka.connect.gcs.templating.Template;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+final class KeyRecordGrouperTest {
+
+    private static final SinkRecord T0P0R0 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "a", null, null, 0);
+    private static final SinkRecord T0P0R1 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "b", null, null, 1);
+    private static final SinkRecord T0P0R2 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 2);
+    private static final SinkRecord T0P0R3 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 3);
+    private static final SinkRecord T0P0R4 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "a", null, null, 4);
+    private static final SinkRecord T0P0R5 = new SinkRecord("topic0", 0, Schema.OPTIONAL_STRING_SCHEMA, "b", null, null, 5);
+
+    private static final SinkRecord T0P1R0 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, "c", null, null, 10);
+    private static final SinkRecord T0P1R1 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, "b", null, null, 11);
+    private static final SinkRecord T0P1R2 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 12);
+    private static final SinkRecord T0P1R3 = new SinkRecord("topic0", 1, Schema.OPTIONAL_STRING_SCHEMA, "c", null, null, 13);
+
+    private static final SinkRecord T1P1R0 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, "d", null, null, 1000);
+    private static final SinkRecord T1P1R1 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, "d", null, null, 1001);
+    private static final SinkRecord T1P1R2 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, null, null, null, 1002);
+    private static final SinkRecord T1P1R3 = new SinkRecord("topic1", 0, Schema.OPTIONAL_STRING_SCHEMA, "a", null, null, 1003);
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "{{topic}}", "{{partition}}", "{{start_offset}}",
+            "{{topic}}-{{partition}}", "{{topic}}-{{start_offset}}", "{{partition}}-{{start_offset}}",
+            "{{topic}}-{{partition}}-{{start_offset}}",
+            "{{topic}}-{{partition}}-{{start_offset}}-{{key}}"
+    })
+    final void incorrectFilenameTemplates(final String template) {
+        final Template filenameTemplate = new Template(template);
+        assertFalse(KeyRecordGrouper.acceptsTemplate(filenameTemplate));
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new KeyRecordGrouper(filenameTemplate));
+        assertEquals(
+                "filenameTemplate must have set of variables {key}, but {"
+                + String.join(",", filenameTemplate.variables())
+                + "} was given",
+                ex.getMessage());
+    }
+
+    @Test
+    final void empty() {
+        final Template filenameTemplate = new Template("{{key}}");
+        assertTrue(KeyRecordGrouper.acceptsTemplate(filenameTemplate));
+        final KeyRecordGrouper grouper = new KeyRecordGrouper(filenameTemplate);
+        assertThat(grouper.records(), anEmptyMap());
+    }
+
+    @Test
+    final void eachKeyInSinglePartition() {
+        final Template filenameTemplate = new Template("{{key}}");
+        assertTrue(KeyRecordGrouper.acceptsTemplate(filenameTemplate));
+        final KeyRecordGrouper grouper = new KeyRecordGrouper(filenameTemplate);
+
+        grouper.put(T0P0R0);
+        grouper.put(T0P0R1);
+        grouper.put(T0P0R2);
+        grouper.put(T0P0R3);
+        grouper.put(T0P0R4);
+        grouper.put(T0P0R5);
+
+        final Map<String, List<SinkRecord>> records = grouper.records();
+        assertThat(records.keySet(), containsInAnyOrder("a", "b", "null"));
+        assertThat(records.get("a"), contains(T0P0R4));
+        assertThat(records.get("b"), contains(T0P0R5));
+        assertThat(records.get("null"), contains(T0P0R3));
+    }
+
+    @Test
+    final void keysInMultiplePartitions() {
+        final Template filenameTemplate = new Template("{{key}}");
+        assertTrue(KeyRecordGrouper.acceptsTemplate(filenameTemplate));
+        final KeyRecordGrouper grouper = new KeyRecordGrouper(filenameTemplate);
+
+        grouper.put(T0P0R0);
+        grouper.put(T0P0R1);
+        grouper.put(T0P0R2);
+        grouper.put(T0P0R3);
+        grouper.put(T0P0R4);
+        grouper.put(T0P0R5);
+
+        grouper.put(T0P1R0);
+        grouper.put(T0P1R1);
+        grouper.put(T0P1R2);
+        grouper.put(T0P1R3);
+
+        grouper.put(T1P1R0);
+        grouper.put(T1P1R1);
+        grouper.put(T1P1R2);
+        grouper.put(T1P1R3);
+
+        final Map<String, List<SinkRecord>> records = grouper.records();
+        assertThat(records.keySet(), containsInAnyOrder("a", "b", "c", "d", "null"));
+        assertThat(records.get("a"), contains(T1P1R3));
+        assertThat(records.get("b"), contains(T0P1R1));
+        assertThat(records.get("c"), contains(T0P1R3));
+        assertThat(records.get("d"), contains(T1P1R1));
+        assertThat(records.get("null"), contains(T1P1R2));
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/templating/TemplateTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/templating/TemplateTest.java
@@ -230,6 +230,6 @@ final class TemplateTest {
     @Test
     void variables() {
         final Template te = new Template("1{{foo}}2{{bar}}3{{baz}}4");
-        assertIterableEquals(Arrays.asList("foo", "bar", "baz"), te.getVariables());
+        assertIterableEquals(Arrays.asList("foo", "bar", "baz"), te.variables());
     }
 }

--- a/src/test/java/io/aiven/kafka/connect/gcs/testutils/BucketAccessor.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/testutils/BucketAccessor.java
@@ -79,6 +79,21 @@ public final class BucketAccessor {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Get blob names with the prefix.
+     *
+     * <p>Doesn't support caching.
+     */
+    public final List<String> getBlobNames(final String prefix) {
+        Objects.requireNonNull(prefix);
+
+        final Storage.BlobListOption blobListOption = Storage.BlobListOption.prefix(prefix);
+        return StreamSupport.stream(storage.list(bucketName, blobListOption).iterateAll().spliterator(), false)
+                .map(BlobInfo::getName)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
     public final void clear(final String prefix) {
         Objects.requireNonNull(prefix);
 


### PR DESCRIPTION
This commit adds support for `{{key}}` file name template, which means
grouping records by the Kafka key.

Also, it allows keys to be `String` and `StringConverter` to be used for
keys.

Closes #14 