### PR TITLE
Improve property-based testing for GcsSinkTask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build
 # IntelliJ IDEA
 /.idea
 /out
+
+# jqwik
+.jqwik-database

--- a/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskGroupByKeyProperties.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskGroupByKeyProperties.java
@@ -1,0 +1,104 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
+import io.aiven.kafka.connect.gcs.config.GcsSinkConfig;
+import io.aiven.kafka.connect.gcs.testutils.BucketAccessor;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a property-based test for {@link GcsSinkTask} (grouping records by the key)
+ * using <a href="https://jqwik.net/docs/current/user-guide.html">jqwik</a>.
+ *
+ * The idea is to generate random batches of {@link SinkRecord}
+ * (see {@link PbtBase#recordBatches()}, put them into a task, and check certain properties
+ * of the written files afterwards. Files are written virtually using the in-memory GCS mock.
+ */
+final class GcsSinkTaskGroupByKeyProperties extends PbtBase {
+
+    @Property
+    final void groupByKey(@ForAll("recordBatches") final List<List<SinkRecord>> recordBatches) {
+        final Storage storage = LocalStorageHelper.getOptions().getService();
+        final BucketAccessor testBucketAccessor = new BucketAccessor(storage, TEST_BUCKET, true);
+
+        final Map<String, String> taskProps = basicTaskProps();
+        taskProps.put(GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, "{{key}}");
+        taskProps.put(GcsSinkConfig.FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG, "none");
+        final GcsSinkTask task = new GcsSinkTask(taskProps, storage);
+
+        for (final List<SinkRecord> recordBatch : recordBatches) {
+            task.put(recordBatch);
+            task.flush(null);
+        }
+
+        final Map<String, SinkRecord> lastRecordPerKey = new HashMap<>();
+        for (final List<SinkRecord> recordBatch : recordBatches) {
+            for (final SinkRecord record : recordBatch) {
+                lastRecordPerKey.put((String) record.key(), record);
+            }
+        }
+
+        // Check expected file names.
+        final List<String> expectedFileNames = lastRecordPerKey.keySet().stream()
+                .map(this::createFilename)
+                .collect(Collectors.toList());
+        assertThat(testBucketAccessor.getBlobNames(), containsInAnyOrder(expectedFileNames.toArray()));
+
+        // Check file contents.
+        for (final String key : lastRecordPerKey.keySet()) {
+            final SinkRecord record = lastRecordPerKey.get(key);
+            final String filename = createFilename(key);
+
+            final List<String> lines = testBucketAccessor.readLines(filename, false);
+            assertThat(lines, hasSize(1));
+
+            final String expectedKeySubstring;
+            if (record.key() == null) {
+                expectedKeySubstring = "";
+            } else {
+                final String keyStr = (String) record.key();
+                expectedKeySubstring = Base64.getEncoder().encodeToString(keyStr.getBytes());
+            }
+            final String expectedValueSubstring = new String((byte[]) record.value(), StandardCharsets.UTF_8);
+            final String expectedLine = String.format("%s,%s,%d",
+                    expectedKeySubstring, expectedValueSubstring, record.kafkaOffset());
+            assertEquals(expectedLine, lines.get(0));
+        }
+    }
+
+    private String createFilename(final String key) {
+        return PREFIX + key;
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskGroupByTopicPartitionProperties.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskGroupByTopicPartitionProperties.java
@@ -23,14 +23,12 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.collect.Lists;
 import io.aiven.kafka.connect.gcs.config.GcsSinkConfig;
 import io.aiven.kafka.connect.gcs.testutils.BucketAccessor;
-import net.jqwik.api.*;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
 import net.jqwik.api.constraints.IntRange;
-import net.jqwik.engine.properties.arbitraries.randomized.RandomGenerators;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -39,26 +37,14 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This is a property-based test for {@link GcsSinkTask} using
- * <a href="https://jqwik.net/docs/current/user-guide.html">jqwik</a>.
+ * This is a property-based test for {@link GcsSinkTask} (grouping records by the topic and partition)
+ * using <a href="https://jqwik.net/docs/current/user-guide.html">jqwik</a>.
  *
  * The idea is to generate random batches of {@link SinkRecord}
- * ({@link GcsSinkTaskProperties#recordBatches()}, put them into a task, and check certain properties
+ * (see {@link PbtBase#recordBatches()}, put them into a task, and check certain properties
  * of the written files afterwards. Files are written virtually using the in-memory GCS mock.
  */
-final class GcsSinkTaskProperties {
-
-    private static final int MAX_TOPICS = 6;
-    private static final int MAX_PARTITIONS_PER_TOPIC = 10;
-    private static final int MAX_START_OFFSET = 20000;
-    private static final int MAX_OFFSET_INCREMENT = 5;
-    private static final int MAX_RECORDS_PER_TRY = 10000;
-    private static final double PROBABILITY_OF_NEW_RECORD_BATCH = 2.0 / MAX_RECORDS_PER_TRY;
-    private static final String TEST_BUCKET = "test-bucket";
-    private static final String PREFIX = "test-dir/";
-    private static final int FIELD_KEY = 0;
-    private static final int FIELD_VALUE = 1;
-    private static final int FIELD_OFFSET = 2;
+final class GcsSinkTaskGroupByTopicPartitionProperties extends PbtBase {
 
     @Property
     final void unlimited(@ForAll("recordBatches") final List<List<SinkRecord>> recordBatches) {
@@ -71,19 +57,15 @@ final class GcsSinkTaskProperties {
         genericTry(recordBatches, maxRecordsPerFile);
     }
 
-    private void genericTry(final List<List<SinkRecord>> recordBatches, final Integer maxRecordsPerFile) {
+    private void genericTry(final List<List<SinkRecord>> recordBatches,
+                            final Integer maxRecordsPerFile) {
         final Storage storage = LocalStorageHelper.getOptions().getService();
         final BucketAccessor testBucketAccessor = new BucketAccessor(storage, TEST_BUCKET, true);
 
-        final Map<String, String> taskProps = new HashMap<>();
-        taskProps.put(GcsSinkConfig.GCS_BUCKET_NAME_CONFIG, TEST_BUCKET);
-        taskProps.put(GcsSinkConfig.FILE_NAME_PREFIX_CONFIG, PREFIX);
-        taskProps.put(GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, "{{topic}}-{{partition}}-{{start_offset}}");
+        final Map<String, String> taskProps = basicTaskProps();
         if (maxRecordsPerFile != null) {
             taskProps.put(GcsSinkConfig.FILE_MAX_RECORDS, Integer.toString(maxRecordsPerFile));
         }
-        taskProps.put(GcsSinkConfig.FORMAT_OUTPUT_FIELDS_CONFIG, "key,value,offset");
-
         final GcsSinkTask task = new GcsSinkTask(taskProps, storage);
 
         for (final List<SinkRecord> recordBatch : recordBatches) {
@@ -197,91 +179,6 @@ final class GcsSinkTaskProperties {
             for (int i = 0; i < offsets.size() - 1; i++) {
                 assertTrue(offsets.get(i) < offsets.get(i + 1));
             }
-        }
-    }
-
-    @Provide
-    private Arbitrary<List<List<SinkRecord>>> recordBatches() {
-        final RandomGenerator<String> keyGenerator = RandomGenerators.samples(
-                new String[]{"key0", "key1", "key2", "key3", null});
-
-        // TODO make generated lists shrinkable
-        return Arbitraries.randomValue(random -> {
-            final List<TopicPartition> topicPartitions = new ArrayList<>();
-            final Map<TopicPartition, SinkRecordBuilder> recordBuilders = new HashMap<>();
-
-            // Randomly pick the number of topics.
-            final int topicCount = random.nextInt(MAX_TOPICS - 1) + 1;
-            for (int topicIdx = 0; topicIdx < topicCount; topicIdx++) {
-                // Randomly pick the number of partitions for a particular topic.
-                final int partitionCount = random.nextInt(MAX_PARTITIONS_PER_TOPIC - 1) + 1;
-                for (int partitionIdx = 0; partitionIdx < partitionCount; partitionIdx++) {
-                    final TopicPartition tp = new TopicPartition("topic" + topicIdx, partitionIdx);
-                    topicPartitions.add(tp);
-                    recordBuilders.put(tp, new SinkRecordBuilder(random, keyGenerator, tp.topic(), tp.partition()));
-                }
-            }
-
-            // Randomly pick the number of records to generate in this try.
-            final int numberOrRecords = random.nextInt(MAX_RECORDS_PER_TRY);
-            final List<List<SinkRecord>> result = new ArrayList<>(numberOrRecords);
-            result.add(new ArrayList<>());
-            for (int i = 0; i < numberOrRecords; i++) {
-                if (random.nextDouble() < PROBABILITY_OF_NEW_RECORD_BATCH) {
-                    result.add(new ArrayList<>());
-                }
-                final TopicPartition tp = topicPartitions.get(random.nextInt(topicPartitions.size()));
-                final List<SinkRecord> currentBatch = result.get(result.size() - 1);
-                currentBatch.add(recordBuilders.get(tp).build());
-            }
-            return result;
-        });
-    }
-
-    private static class SinkRecordBuilder {
-        private final Random random;
-        private final RandomGenerator<String> keyGenerator;
-        private final String topic;
-        private final int partition;
-
-        private int offset;
-
-        private SinkRecordBuilder(final Random random,
-                                  final RandomGenerator<String> keyGenerator,
-                                  final String topic,
-                                  final int partition) {
-            this.random = random;
-            this.keyGenerator = keyGenerator;
-            this.topic = topic;
-            this.partition = partition;
-            // In a particular topic-partition, start from a random offset.
-            this.offset = random.nextInt(MAX_START_OFFSET);
-        }
-
-        final SinkRecord build() {
-            final String key = keyGenerator.next(random).value();
-            final byte[] keyBytes;
-            if (key != null) {
-                keyBytes = key.getBytes(StandardCharsets.UTF_8);
-            } else {
-                keyBytes = null;
-            }
-
-            final String value = topic + "-" + partition;
-            final byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
-
-            final SinkRecord record = new SinkRecord(
-                    topic,
-                    partition,
-                    Schema.OPTIONAL_BYTES_SCHEMA,
-                    keyBytes,
-                    Schema.OPTIONAL_BYTES_SCHEMA,
-                    valueBytes,
-                    offset);
-            // Imitate gaps in offsets.
-            final int offsetIncrement = random.nextInt(MAX_OFFSET_INCREMENT - 1) + 1;
-            offset += offsetIncrement;
-            return record;
         }
     }
 

--- a/src/test/java/io/aiven/kafka/connect/gcs/PbtBase.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/PbtBase.java
@@ -1,0 +1,134 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import io.aiven.kafka.connect.gcs.config.GcsSinkConfig;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Provide;
+import net.jqwik.api.RandomGenerator;
+import net.jqwik.engine.properties.arbitraries.randomized.RandomGenerators;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+abstract class PbtBase {
+    private static final int MAX_TOPICS = 6;
+    private static final int MAX_PARTITIONS_PER_TOPIC = 10;
+    private static final int MAX_START_OFFSET = 20000;
+    private static final int MAX_OFFSET_INCREMENT = 5;
+    private static final int MAX_RECORDS_PER_TRY = 10000;
+    private static final double PROBABILITY_OF_NEW_RECORD_BATCH = 2.0 / MAX_RECORDS_PER_TRY;
+
+    static final String TEST_BUCKET = "test-bucket";
+    static final String PREFIX = "test-dir/";
+
+    static final int FIELD_KEY = 0;
+    static final int FIELD_VALUE = 1;
+    static final int FIELD_OFFSET = 2;
+
+    @Provide
+    final Arbitrary<List<List<SinkRecord>>> recordBatches() {
+        final RandomGenerator<String> keyGenerator = RandomGenerators.samples(
+                new String[]{"key0", "key1", "key2", "key3", null});
+
+        // TODO make generated lists shrinkable
+        return Arbitraries.randomValue(random -> {
+            final List<TopicPartition> topicPartitions = new ArrayList<>();
+            final Map<TopicPartition, SinkRecordBuilder> recordBuilders = new HashMap<>();
+
+            // Randomly pick the number of topics.
+            final int topicCount = random.nextInt(MAX_TOPICS - 1) + 1;
+            for (int topicIdx = 0; topicIdx < topicCount; topicIdx++) {
+                // Randomly pick the number of partitions for a particular topic.
+                final int partitionCount = random.nextInt(MAX_PARTITIONS_PER_TOPIC - 1) + 1;
+                for (int partitionIdx = 0; partitionIdx < partitionCount; partitionIdx++) {
+                    final TopicPartition tp = new TopicPartition("topic" + topicIdx, partitionIdx);
+                    topicPartitions.add(tp);
+                    recordBuilders.put(tp, new SinkRecordBuilder(random, keyGenerator, tp.topic(), tp.partition()));
+                }
+            }
+
+            // Randomly pick the number of records to generate in this try.
+            final int numberOrRecords = random.nextInt(MAX_RECORDS_PER_TRY);
+            final List<List<SinkRecord>> result = new ArrayList<>(numberOrRecords);
+            result.add(new ArrayList<>());
+            for (int i = 0; i < numberOrRecords; i++) {
+                if (random.nextDouble() < PROBABILITY_OF_NEW_RECORD_BATCH) {
+                    result.add(new ArrayList<>());
+                }
+                final TopicPartition tp = topicPartitions.get(random.nextInt(topicPartitions.size()));
+                final List<SinkRecord> currentBatch = result.get(result.size() - 1);
+                currentBatch.add(recordBuilders.get(tp).build());
+            }
+            return result;
+        });
+    }
+
+    private static class SinkRecordBuilder {
+        private final Random random;
+        private final RandomGenerator<String> keyGenerator;
+        private final String topic;
+        private final int partition;
+
+        private int offset;
+
+        private SinkRecordBuilder(final Random random,
+                                  final RandomGenerator<String> keyGenerator,
+                                  final String topic,
+                                  final int partition) {
+            this.random = random;
+            this.keyGenerator = keyGenerator;
+            this.topic = topic;
+            this.partition = partition;
+            // In a particular topic-partition, start from a random offset.
+            this.offset = random.nextInt(MAX_START_OFFSET);
+        }
+
+        final SinkRecord build() {
+            final String key = keyGenerator.next(random).value();
+            final String value = topic + "-" + partition;
+
+            final SinkRecord record = new SinkRecord(
+                    topic,
+                    partition,
+                    Schema.OPTIONAL_STRING_SCHEMA,
+                    key,
+                    Schema.OPTIONAL_BYTES_SCHEMA,
+                    value.getBytes(StandardCharsets.UTF_8),
+                    offset);
+            // Imitate gaps in offsets.
+            final int offsetIncrement = random.nextInt(MAX_OFFSET_INCREMENT - 1) + 1;
+            offset += offsetIncrement;
+            return record;
+        }
+    }
+
+    Map<String, String> basicTaskProps() {
+        final Map<String, String> taskProps = new HashMap<>();
+        taskProps.put(GcsSinkConfig.GCS_BUCKET_NAME_CONFIG, TEST_BUCKET);
+        taskProps.put(GcsSinkConfig.FILE_NAME_PREFIX_CONFIG, PREFIX);
+        taskProps.put(GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, "{{topic}}-{{partition}}-{{start_offset}}");
+        taskProps.put(GcsSinkConfig.FORMAT_OUTPUT_FIELDS_CONFIG, "key,value,offset");
+        return taskProps;
+    }
+}


### PR DESCRIPTION
This PR makes two changes to property-based testing for `GcsSinkTask`:
- makes record lists generated in property-based tests to be cut into batches between which a flush occurs;
- adds property-based tests for group-by-key mode.
