### PR TITLE
Add unit tests to io.aiven.kafka.connect

### DIFF
--- a/src/test/java/io/aiven/kafka/connect/gcs/config/CompressionTypeTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/CompressionTypeTest.java
@@ -1,0 +1,30 @@
+package io.aiven.kafka.connect.gcs.config;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CompressionTypeTest {
+
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void forNameInputNotNullOutputGzip() {
+
+    // Act
+    final CompressionType actual = CompressionType.forName("gZIp");
+
+    // Assert result
+    assertEquals(CompressionType.GZIP, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void forNameInputNotNullOutputNone() {
+
+    // Act
+    final CompressionType actual = CompressionType.forName("nOnE");
+
+    // Assert result
+    assertEquals(CompressionType.NONE, actual);
+  }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/OutputFieldEncodingTypeTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/OutputFieldEncodingTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OutputFieldEncodingTypeTest {
+
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void forNameInputNotNullOutputBase64() {
+
+        // Act
+        final OutputFieldEncodingType actual = OutputFieldEncodingType.forName("BAsE64");
+
+        // Assert result
+        assertEquals(OutputFieldEncodingType.BASE64, actual);
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void forNameInputNotNullOutputNone() {
+
+        // Act
+        final OutputFieldEncodingType actual = OutputFieldEncodingType.forName("nOnE");
+
+        // Assert result
+        assertEquals(OutputFieldEncodingType.NONE, actual);
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/OutputFieldTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/OutputFieldTest.java
@@ -1,0 +1,71 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class OutputFieldTest {
+
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void equalsInputNullOutputFalse() {
+
+        // Arrange
+        final OutputField outputField =
+            new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE);
+
+        // Act and Assert result
+        assertFalse(outputField.equals(null));
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void getEncodingTypeOutputNone() {
+
+        // Arrange
+        final OutputField outputField =
+            new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE);
+
+        // Act
+        final OutputFieldEncodingType actual = outputField.getEncodingType();
+
+        // Assert result
+        assertEquals(OutputFieldEncodingType.NONE, actual);
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void getFieldTypeOutputKey() {
+
+        // Arrange
+        final OutputField outputField =
+            new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE);
+
+        // Act
+        final OutputFieldType actual = outputField.getFieldType();
+
+        // Assert result
+        assertEquals(OutputFieldType.KEY, actual);
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/OutputFieldTypeTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/OutputFieldTypeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OutputFieldTypeTest {
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void forNameInputNotNullOutputKey() {
+
+        // Act
+        final OutputFieldType actual = OutputFieldType.forName("KEY");
+
+        // Assert result
+        assertEquals(OutputFieldType.KEY, actual);
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void forNameInputNotNullOutputOffset() {
+
+        // Act
+        final OutputFieldType actual = OutputFieldType.forName("OFFSET");
+
+        // Assert result
+        assertEquals(OutputFieldType.OFFSET, actual);
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void forNameInputNotNullOutputTimestamp() {
+
+        // Act
+        final OutputFieldType actual = OutputFieldType.forName("TIMestamP");
+
+        // Assert result
+        assertEquals(OutputFieldType.TIMESTAMP, actual);
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void forNameInputNotNullOutputValue() {
+
+        // Act
+        final OutputFieldType actual = OutputFieldType.forName("VALue");
+
+        // Assert result
+        assertEquals(OutputFieldType.VALUE, actual);
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/output/PlainValueWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/output/PlainValueWriterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs.output;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+
+public class PlainValueWriterTest {
+
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void getOutputBytesInput0Output0() {
+
+        // Arrange
+        final PlainValueWriter plainValueWriter = new PlainValueWriter();
+        final byte[] value = {};
+
+        // Act
+        final byte[] actual = plainValueWriter.getOutputBytes(value);
+
+        // Assert result
+        assertArrayEquals(new byte[] {}, actual);
+    }
+
+    // Test written by Diffblue Cover.
+    @Test
+    public void getOutputBytesInputNullOutputNull() {
+
+        // Arrange
+        final PlainValueWriter plainValueWriter = new PlainValueWriter();
+
+        // Act and Assert result
+        assertNull(plainValueWriter.getOutputBytes(null));
+    }
+}


### PR DESCRIPTION
Hi. I've analysed your codebase and noticed that it is not fully tested. 
I've written some tests for the methods in the following classes with the help of [Diffblue Cover](https://www.diffblue.com/opensource): 
- io.aiven.kafka.connect.gcs.config;
- io.aiven.kafka.connect.gcs.output


Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.