### PR TITLE
Add HourlyTopicPartitionRecordGrouper

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
@@ -92,7 +92,9 @@ public final class GcsSinkTask extends SinkTask {
         }
 
         final Template filenameTemplate = config.getFilenameTemplate();
-        if (TopicPartitionRecordGrouper.acceptsTemplate(filenameTemplate)) {
+        if (HourlyTopicPartitionRecordGrouper.acceptsTemplate(filenameTemplate)) {
+            this.recordGrouper = new HourlyTopicPartitionRecordGrouper(filenameTemplate, maxRecordsPerFile);
+        } else if (TopicPartitionRecordGrouper.acceptsTemplate(filenameTemplate)) {
             this.recordGrouper = new TopicPartitionRecordGrouper(filenameTemplate, maxRecordsPerFile);
         } else if (KeyRecordGrouper.acceptsTemplate(filenameTemplate)) {
             if (maxRecordsPerFile == null) {

--- a/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
@@ -62,6 +62,11 @@ final class HourlyTopicPartitionRecordGrouper extends TopicPartitionRecordGroupe
     }
 
     @Override
+    protected boolean acceptsTemplateInstance(final Template filenameTemplate) {
+        return HourlyTopicPartitionRecordGrouper.acceptsTemplate(filenameTemplate);
+    }
+
+    @Override
     protected Instance renderFilename(final TopicPartition tp, final SinkRecord headRecord) {
         final LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
@@ -1,0 +1,82 @@
+/*
+ * Aiven Kafka GCS Connector
+ * Copyright (c) 2019 Aiven Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.gcs.config.FilenameTemplateVariable;
+import io.aiven.kafka.connect.gcs.templating.Template;
+import io.aiven.kafka.connect.gcs.templating.Template.Instance;
+
+
+/**
+ * A {@link RecordGrouper} that groups records by topic and partition.
+ *
+ * <p>The class requires a filename template with {@code topic}, {@code partition},
+ * and {@code start_offset} variables declared.
+ *
+ * <p>The class supports limited and unlimited number of records in files.
+ */
+final class HourlyTopicPartitionRecordGrouper extends TopicPartitionRecordGrouper {
+    private static final List<String> EXPECTED_VARIABLE_LIST = Arrays.asList(
+        FilenameTemplateVariable.TOPIC.name,
+        FilenameTemplateVariable.PARTITION.name,
+        FilenameTemplateVariable.START_OFFSET.name,
+        FilenameTemplateVariable.YEAR.name,
+        FilenameTemplateVariable.MONTH.name,
+        FilenameTemplateVariable.DAY.name,
+        FilenameTemplateVariable.HOUR.name
+    );
+
+
+     /**
+     * A constructor.
+     *
+     * @param filenameTemplate  the filename template.
+     * @param maxRecordsPerFile the maximum number of records per file ({@code null} for unlimited).
+     */
+    public HourlyTopicPartitionRecordGrouper(final Template filenameTemplate, final Integer maxRecordsPerFile) {
+        super(filenameTemplate, maxRecordsPerFile);
+    }
+
+    @Override
+    protected Instance renderFilename(final TopicPartition tp, final SinkRecord headRecord) {
+        final LocalDateTime now = LocalDateTime.now();
+
+        return super.renderFilename(tp, headRecord)
+            .bindVariable(FilenameTemplateVariable.YEAR.name, () -> Integer.toString(now.getYear()))
+            .bindVariable(FilenameTemplateVariable.MONTH.name, () -> Integer.toString(now.getMonthValue()))
+            .bindVariable(FilenameTemplateVariable.DAY.name, () -> Integer.toString(now.getDayOfMonth()))
+            .bindVariable(FilenameTemplateVariable.HOUR.name, () -> Integer.toString(now.getHour()));
+    }
+
+        /**
+     * Checks if the template is acceptable for this grouper.
+     */
+    static boolean acceptsTemplate(final Template filenameTemplate) {
+        return new HashSet<>(EXPECTED_VARIABLE_LIST).equals(filenameTemplate.variablesSet());
+    }
+}
+}

--- a/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
@@ -32,10 +32,10 @@ import io.aiven.kafka.connect.gcs.templating.Template.Instance;
 
 
 /**
- * A {@link RecordGrouper} that groups records by topic and partition.
+ * A {@link RecordGrouper} that groups records by topic and partition, as well as by year/month/day/hour
  *
- * <p>The class requires a filename template with {@code topic}, {@code partition},
- * and {@code start_offset} variables declared.
+ * <p>The class requires a filename template with {@code topic}, {@code partition}, {@code start_offset},
+ * as well as {@code year}, {@code month}, {@code day}, {@code hour} variables declared.
  *
  * <p>The class supports limited and unlimited number of records in files.
  */
@@ -67,19 +67,19 @@ final class HourlyTopicPartitionRecordGrouper extends TopicPartitionRecordGroupe
     }
 
     @Override
-    protected Instance renderFilename(final TopicPartition tp, final SinkRecord headRecord) {
+    protected Instance bindFilenameTemplate(final TopicPartition tp, final SinkRecord headRecord) {
         final LocalDateTime now = LocalDateTime.now();
 
-        return super.renderFilename(tp, headRecord)
+        return super.bindFilenameTemplate(tp, headRecord)
             .bindVariable(FilenameTemplateVariable.YEAR.name, () -> Integer.toString(now.getYear()))
             .bindVariable(FilenameTemplateVariable.MONTH.name, () -> Integer.toString(now.getMonthValue()))
             .bindVariable(FilenameTemplateVariable.DAY.name, () -> Integer.toString(now.getDayOfMonth()))
             .bindVariable(FilenameTemplateVariable.HOUR.name, () -> Integer.toString(now.getHour()));
     }
 
-        /**
-     * Checks if the template is acceptable for this grouper.
-     */
+    /**
+    * Checks if the template is acceptable for this grouper.
+    */
     static boolean acceptsTemplate(final Template filenameTemplate) {
         return new HashSet<>(EXPECTED_VARIABLE_LIST).equals(filenameTemplate.variablesSet());
     }

--- a/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/HourlyTopicPartitionRecordGrouper.java
@@ -20,7 +20,7 @@ package io.aiven.kafka.connect.gcs;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.kafka.common.TopicPartition;
@@ -78,5 +78,4 @@ final class HourlyTopicPartitionRecordGrouper extends TopicPartitionRecordGroupe
     static boolean acceptsTemplate(final Template filenameTemplate) {
         return new HashSet<>(EXPECTED_VARIABLE_LIST).equals(filenameTemplate.variablesSet());
     }
-}
 }

--- a/src/main/java/io/aiven/kafka/connect/gcs/TopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/TopicPartitionRecordGrouper.java
@@ -49,8 +49,8 @@ class TopicPartitionRecordGrouper implements RecordGrouper {
         FilenameTemplateVariable.START_OFFSET.name
     );
 
-    private final Template filenameTemplate;
-    private final Integer maxRecordsPerFile;
+    protected final Template filenameTemplate;
+    protected final Integer maxRecordsPerFile;
 
     private final Map<TopicPartition, SinkRecord> currentHeadRecords = new HashMap<>();
     private final Map<String, List<SinkRecord>> fileBuffers = new HashMap<>();
@@ -64,7 +64,7 @@ class TopicPartitionRecordGrouper implements RecordGrouper {
     public TopicPartitionRecordGrouper(final Template filenameTemplate, final Integer maxRecordsPerFile) {
         Objects.requireNonNull(filenameTemplate);
 
-        if (!acceptsTemplate(filenameTemplate)) {
+        if (!this.acceptsTemplateInstance(filenameTemplate)) {
             throw new IllegalArgumentException(
                 "filenameTemplate must have set of variables {"
                     + String.join(",", EXPECTED_VARIABLE_LIST)
@@ -94,6 +94,10 @@ class TopicPartitionRecordGrouper implements RecordGrouper {
         } else {
             fileBuffers.computeIfAbsent(filename, ignored -> new ArrayList<>()).add(record);
         }
+    }
+
+    protected boolean acceptsTemplateInstance(final Template filenameTemplate) {
+        return TopicPartitionRecordGrouper.acceptsTemplate(filenameTemplate);
     }
 
     protected Instance renderFilename(final TopicPartition tp, final SinkRecord headRecord) {

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateValidator.java
@@ -43,6 +43,15 @@ final class FilenameTemplateValidator implements ConfigDef.Validator {
                 FilenameTemplateVariable.START_OFFSET.name)
         );
         SUPPORTED_VARIABLES_SETS.add(
+            Sets.newHashSet(FilenameTemplateVariable.TOPIC.name,
+                FilenameTemplateVariable.PARTITION.name,
+                FilenameTemplateVariable.START_OFFSET.name,
+                FilenameTemplateVariable.YEAR.name,
+                FilenameTemplateVariable.MONTH.name,
+                FilenameTemplateVariable.DAY.name,
+                FilenameTemplateVariable.HOUR.name)
+        );
+        SUPPORTED_VARIABLES_SETS.add(
             Sets.newHashSet(FilenameTemplateVariable.KEY.name)
         );
     }

--- a/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateVariable.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/config/FilenameTemplateVariable.java
@@ -22,7 +22,11 @@ public enum FilenameTemplateVariable {
     TOPIC("topic"),
     PARTITION("partition"),
     START_OFFSET("start_offset"),
-    KEY("key");
+    KEY("key"),
+    HOUR("hour"),
+    DAY("day"),
+    MONTH("month"),
+    YEAR("year");
 
     public final String name;
 

--- a/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
@@ -110,6 +110,21 @@ final class GcsSinkTaskTest {
     }
 
     @Test
+    final void basicNewTemplate() {
+        final String template = "{{year}/{{month}}/{{day}}/{{hour}}/{{topic}}-{{partition}}-{{start_offset}}";
+        properties.put(GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, template);
+
+        final GcsSinkTask task = new GcsSinkTask(properties, storage);
+
+        task.put(basicRecords);
+        task.flush(null);
+
+        assertIterableEquals(
+            Lists.newArrayList("topic0-0-10", "topic0-1-20", "topic0-2-50", "topic1-0-30", "topic1-1-40"),
+            testBucketAccessor.getBlobNames());
+    }
+
+    @Test
     final void basicValuesPlain() {
         properties.put(GcsSinkConfig.FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG, "none");
         final GcsSinkTask task = new GcsSinkTask(properties, storage);

--- a/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
@@ -40,6 +40,7 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.threeten.bp.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -111,7 +112,7 @@ final class GcsSinkTaskTest {
 
     @Test
     final void basicNewTemplate() {
-        final String template = "{{year}/{{month}}/{{day}}/{{hour}}/{{topic}}-{{partition}}-{{start_offset}}";
+        final String template = "{{year}}/{{month}}/{{day}}/{{hour}}/{{topic}}-{{partition}}-{{start_offset}}";
         properties.put(GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, template);
 
         final GcsSinkTask task = new GcsSinkTask(properties, storage);
@@ -119,8 +120,22 @@ final class GcsSinkTaskTest {
         task.put(basicRecords);
         task.flush(null);
 
+        final LocalDateTime now = LocalDateTime.now();
+        final String prefix = String.format("%d/%d/%d/%d/",
+            now.getYear(),
+            now.getMonthValue(),
+            now.getDayOfMonth(),
+            now.getHour()
+        );
+
         assertIterableEquals(
-            Lists.newArrayList("topic0-0-10", "topic0-1-20", "topic0-2-50", "topic1-0-30", "topic1-1-40"),
+            Lists.newArrayList(
+                prefix + "topic0-0-10",
+                prefix + "topic0-1-20",
+                prefix + "topic0-2-50",
+                prefix + "topic1-0-30",
+                prefix + "topic1-1-40"
+            ),
             testBucketAccessor.getBlobNames());
     }
 

--- a/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/GcsSinkTaskTest.java
@@ -111,7 +111,7 @@ final class GcsSinkTaskTest {
     }
 
     @Test
-    final void basicNewTemplate() {
+    final void withTimebasedGrouping() {
         final String template = "{{year}}/{{month}}/{{day}}/{{hour}}/{{topic}}-{{partition}}-{{start_offset}}";
         properties.put(GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, template);
 

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -32,15 +32,18 @@ import org.apache.kafka.common.config.ConfigException;
 
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.io.Resources;
+import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 /**
  * Tests {@link GcsSinkConfig} class.
@@ -178,10 +181,7 @@ final class GcsSinkConfigTest {
         final Throwable t = assertThrows(
             ConfigException.class, () -> new GcsSinkConfig(properties)
         );
-        assertEquals("Invalid value [key, value, offset, timestamp, unsupported] "
-                + "for configuration format.output.fields: "
-                + "supported values are: 'key', 'value', 'offset', 'timestamp'",
-            t.getMessage());
+        assertThat(t.getMessage(), StringContains.containsString("supported values are:"));
     }
 
     @Test
@@ -378,9 +378,7 @@ final class GcsSinkConfigTest {
         final Throwable t = assertThrows(
             ConfigException.class,
             () -> new GcsSinkConfig(properties));
-        assertEquals("Invalid value  for configuration file.name.template: "
-                + "unsupported set of template variables, supported sets are: topic,partition,start_offset; key",
-            t.getMessage());
+        assertThat(t.getMessage(), StringContains.containsString("supported sets are:"));
     }
 
     @Test
@@ -392,10 +390,7 @@ final class GcsSinkConfigTest {
         final Throwable t = assertThrows(
             ConfigException.class,
             () -> new GcsSinkConfig(properties));
-        assertEquals("Invalid value {{ aaa }}{{ topic }}{{ partition }}{{ start_offset }} "
-                + "for configuration file.name.template: "
-                + "unsupported set of template variables, supported sets are: topic,partition,start_offset; key",
-            t.getMessage());
+        assertThat(t.getMessage(), StringContains.containsString("supported sets are:"));
     }
 
     @Test
@@ -407,9 +402,7 @@ final class GcsSinkConfigTest {
         final Throwable t = assertThrows(
             ConfigException.class,
             () -> new GcsSinkConfig(properties));
-        assertEquals("Invalid value {{ partition }}{{ start_offset }} for configuration file.name.template: "
-                + "unsupported set of template variables, supported sets are: topic,partition,start_offset; key",
-            t.getMessage());
+        assertThat(t.getMessage(), StringContains.containsString("supported sets are:"));
     }
 
     @Test
@@ -421,9 +414,7 @@ final class GcsSinkConfigTest {
         final Throwable t = assertThrows(
             ConfigException.class,
             () -> new GcsSinkConfig(properties));
-        assertEquals("Invalid value {{ topic }}{{ start_offset }} for configuration file.name.template: "
-                + "unsupported set of template variables, supported sets are: topic,partition,start_offset; key",
-            t.getMessage());
+        assertThat(t.getMessage(), StringContains.containsString("supported sets are:"));
     }
 
     @Test
@@ -435,9 +426,7 @@ final class GcsSinkConfigTest {
         final Throwable t = assertThrows(
             ConfigException.class,
             () -> new GcsSinkConfig(properties));
-        assertEquals("Invalid value {{ topic }}{{ partition }} for configuration file.name.template: "
-                + "unsupported set of template variables, supported sets are: topic,partition,start_offset; key",
-            t.getMessage());
+        assertThat(t.getMessage(), StringContains.containsString("supported sets are:"));
     }
 
     @Test


### PR DESCRIPTION
Hi. 

I was searching for open source plugin for kafka connect that allows to send data to GC. This one came first in my google search. 

I tried it and it seems to works nice, but does not allow partitioning by time. What we need is following folder structure

```{{year}}/{{month}}/{{day}}/{{hour}}```

So I tried to extend your code to support that. I am quite far from Java world, so it can definitely be improved. 

However, what do u think about merging it into upstream?