### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ gcs.credentials.json={"type":"...", ...}
 
 
 # The set of the fields that are to be output, comma separated.
-# Supported values are: `key`, `value`, `offset`, `timestamp`, and `headers`.
+# Supported values are: `key`, `value`, `offset`, `timestamp`.
 # Optional, the default is `value`.
-format.output.fields=key,value,offset,timestamp,headers
+format.output.fields=key,value,offset,timestamp
 
 # The prefix to be added to the name of each file put on GCS.
 # See the GCS naming requirements https://cloud.google.com/storage/docs/naming


### PR DESCRIPTION
`headers` currently not supported as a value in `format.output.fields`