### PR TITLE
Don't use env variable for version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ plugins {
 }
 
 group = "io.aiven"
-version = System.getenv("RELEASE_VERSION") ?: "0-SNAPSHOT"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
We have the version defined in `gradle.properties`.