### PR TITLE
Add Jsonl output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,26 @@ non-deterministic.
 Output files are text files that contain one record per line (i.e.,
 they're separated by `\n`).
 
+There are two types of data format available: 
+ - **[Default]** Flat structure, where field values are separated by comma (`csv`)
+    
+    Configuration: ```format.output.type=csv```. 
+    Also, this is the default if the property is not present in the configuration.
+    
+ - Complex structure, where file is in format of [JSON lines](https://jsonlines.org/). 
+    It contains one record per line and each line is a valid JSON object(`jsonl`)
+ 
+    Configuration: ```format.output.type=jsonl```. 
+
 The connector can output the following fields from records into the
-output: the key, the value, the timestamp, and the offset. (The set and the order of
+output: the key, the value, the timestamp, and the offset. (The set of
 these output fields is configurable.) The field values are separated by comma.
+
+It is possible to control the number of records to be put in a
+particular output file by setting `file.max.records`. By default, it is
+`0`, which is interpreted as "unlimited".
+
+#### CSV Format example
 
 The key and the value—if they're output—are stored as binaries encoded
 in [Base64](https://en.wikipedia.org/wiki/Base64).
@@ -197,9 +214,38 @@ output instead:
 ,,,1554210895
 ```
 
-It is possible to control the number of records to be put in a
-particular output file by setting `file.max.records`. By default, it is
-`0`, which is interpreted as "unlimited".
+**NB!**
+
+ - The `key.converter` property must be set to `org.apache.kafka.connect.converters.ByteArrayConverter`
+or `org.apache.kafka.connect.storage.StringConverter` for this data format.
+
+ - The `value.converter` property must be set to `org.apache.kafka.connect.converters.ByteArrayConverter` for this data format.
+
+#### JSONL Format example
+
+For example, if we output `key,value,offset,timestamp`, a record line might look like:
+
+```
+{ "key": "k1", "value": "v0", "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+```
+
+OR
+
+```
+{ "key": "user1", "value": {"name": "John", "address": {"city": "London"}}, "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+```
+
+It is recommended to use
+- `org.apache.kafka.connect.storage.StringConverter` or 
+- `org.apache.kafka.connect.json.JsonConverter`
+ 
+as `key.converter` or `value.converter` to make an output file human-readable.
+
+**NB!**
+
+ - The value of the `format.output.fields.value.encoding` property is ignored for this data format.
+ - Value/Key schema will not be presented in output file, even if `value.converter.schemas.enable` property is `true`.
+ But, it is still important to set this property correctly, so that connector could read records correctly. 
 
 ## Configuration
 
@@ -225,13 +271,19 @@ name=my-gcs-connector
 connector.class=io.aiven.kafka.connect.gcs.GcsSinkConnector
 
 # The key converter for this connector
-# (must be set to org.apache.kafka.connect.converters.ByteArrayConverter
-# or org.apache.kafka.connect.storage.StringConverter)
-key.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+key.converter=org.apache.kafka.connect.storage.StringConverter
 
 # The value converter for this connector
-# (must be set to ByteArrayConverter)
-value.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+value.converter=org.apache.kafka.connect.json.JsonConverter
+
+# Identify, if value contains a schema.
+# Required value converter is `org.apache.kafka.connect.json.JsonConverter`.
+value.converter.schemas.enable=false
+
+# The type of data format used to write data to the GCS output files.
+# The supported values are: `csv`, `jsonl`.
+# Optional, the default is `csv`.
+format.output.type=jsonl
 
 # A comma-separated list of topics to use as input for this connector
 # Also a regular expression version `topics.regex` is supported.

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ javadoc {
 
 ext {
     kafkaVersion = "1.1.0"
-    aivenConnectCommonsVersion = "0.1.0"
+    aivenConnectCommonsVersion = "0.2.0"
     testcontainersVersion = "1.12.0"
 }
 
@@ -132,6 +132,7 @@ dependencies {
 
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     testImplementation "org.apache.kafka:connect-runtime:$kafkaVersion"
+    testImplementation "org.apache.kafka:connect-json:$kafkaVersion"
     testImplementation 'com.google.cloud:google-cloud-nio:0.84.0-alpha'
     testImplementation  'org.mockito:mockito-core:3.3.3'
     testImplementation "io.aiven:aiven-kafka-connect-commons:$aivenConnectCommonsVersion"

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -273,6 +273,8 @@ public final class GcsSinkConfig extends AivenCommonConfig {
     private static void addFormatConfigGroup(final ConfigDef configDef) {
         int formatGroupCounter = 0;
 
+        addFormatTypeConfig(configDef, formatGroupCounter);
+
         final String supportedOutputFields = OutputFieldType.names().stream()
             .map(f -> "'" + f + "'")
             .collect(Collectors.joining(", "));

--- a/src/test/java/io/aiven/kafka/connect/gcs/testutils/BucketAccessor.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/testutils/BucketAccessor.java
@@ -191,6 +191,7 @@ public final class BucketAccessor {
         }
     }
 
+
     public final List<List<String>> readAndDecodeLines(final String blobName,
                                                        final String compression,
                                                        final int... fieldsToDecode) {


### PR DESCRIPTION
__WHY__:
GCSSinkTask should be able to store events in a JSONL format.

__WHAT__:
- Added new configuration 'format.output.type'
- Added integration Test for 'jsonl' format(happy case)
- GCSSinkTask Unittest
- README

Configuration refactoring could be in a next review, because it also require a changes in commons