### PR TITLE
Add integration tests for Avro encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,11 @@ OR
 ```
 
 It is recommended to use
-- `org.apache.kafka.connect.storage.StringConverter` or 
-- `org.apache.kafka.connect.json.JsonConverter`
+- `org.apache.kafka.connect.storage.StringConverter`, 
+- `org.apache.kafka.connect.json.JsonConverter`, or
+- `io.confluent.connect.avro.AvroConverter`.
  
-as `key.converter` or `value.converter` to make an output file human-readable.
+as `key.converter` and/or `value.converter` to make output files human-readable.
 
 **NB!**
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,13 @@ group = "io.aiven"
 repositories {
     mavenLocal()
     jcenter()
+    // For Aiven Commons
     maven {
         url "http://dl.bintray.com/aiven/maven"
+    }
+    // For kafka-avro-serializer and kafka-connect-avro-converter
+    maven {
+        url "https://packages.confluent.io/maven"
     }
 }
 
@@ -67,6 +72,9 @@ javadoc {
 
 ext {
     kafkaVersion = "1.1.0"
+    // Compatible with Kafka version:
+    // https://docs.confluent.io/current/installation/versions-interoperability.html
+    confluentPlatformVersion = "4.1.4"
     aivenConnectCommonsVersion = "0.2.0"
     testcontainersVersion = "1.12.0"
 }
@@ -146,6 +154,9 @@ dependencies {
 
     integrationTestImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
     integrationTestImplementation "org.testcontainers:kafka:$testcontainersVersion" // this is not Kafka version
+    integrationTestImplementation "io.confluent:kafka-avro-serializer:$confluentPlatformVersion"
+    integrationTestImplementation "io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion"
+    integrationTestImplementation "org.apache.avro:avro:1.8.1"
     // Make test utils from 'test' available in 'integration-test'
     integrationTestImplementation sourceSets.test.output
 

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/AbstractIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/AbstractIntegrationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import io.aiven.kafka.connect.common.config.CompressionType;
+import io.aiven.kafka.connect.gcs.testutils.BucketAccessor;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.junit.jupiter.api.BeforeAll;
+
+abstract class AbstractIntegrationTest {
+    protected static final String TEST_TOPIC_0 = "test-topic-0";
+    protected static final String TEST_TOPIC_1 = "test-topic-1";
+
+    protected static String gcsCredentialsPath;
+    protected static String gcsCredentialsJson;
+
+    protected static String testBucketName;
+
+    protected static String gcsPrefix;
+
+    protected static BucketAccessor testBucketAccessor;
+
+    protected static File pluginDir;
+
+    @BeforeAll
+    static void setUpAll() throws IOException, InterruptedException {
+        gcsCredentialsPath = System.getProperty("integration-test.gcs.credentials.path");
+        gcsCredentialsJson = System.getProperty("integration-test.gcs.credentials.json");
+
+        testBucketName = System.getProperty("integration-test.gcs.bucket");
+
+        final Storage storage = StorageOptions.newBuilder()
+            .setCredentials(GoogleCredentialsBuilder.build(gcsCredentialsPath, gcsCredentialsJson))
+            .build()
+            .getService();
+        testBucketAccessor = new BucketAccessor(storage, testBucketName);
+        testBucketAccessor.ensureWorking();
+
+        gcsPrefix = "aiven-kafka-connect-gcs-test-"
+            + ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "/";
+
+        final File testDir = Files.createTempDirectory("aiven-kafka-connect-gcs-test-").toFile();
+
+        pluginDir = new File(testDir, "plugins/aiven-kafka-connect-gcs/");
+        assert pluginDir.mkdirs();
+
+        final File distFile = new File(System.getProperty("integration-test.distribution.file.path"));
+        assert distFile.exists();
+
+        final String cmd = String.format("tar -xf %s --strip-components=1 -C %s",
+            distFile.toString(), pluginDir.toString());
+        final Process p = Runtime.getRuntime().exec(cmd);
+        assert p.waitFor() == 0;
+    }
+
+    protected String getBlobName(final int partition, final int startOffset, final String compression) {
+        final String result = String.format("%s%s-%d-%d", gcsPrefix, TEST_TOPIC_0, partition, startOffset);
+        return result + CompressionType.forName(compression).extension();
+    }
+
+    protected String getBlobName(final String key, final String compression) {
+        final String result = String.format("%s%s", gcsPrefix, key);
+        return result + CompressionType.forName(compression).extension();
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroIntegrationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+@Testcontainers
+final class AvroIntegrationTest extends AbstractIntegrationTest {
+    private static final String CONNECTOR_NAME = "aiven-gcs-sink-connector";
+
+    private static final int OFFSET_FLUSH_INTERVAL_MS = 5000;
+
+    @Container
+    private final KafkaContainer kafka = new KafkaContainer()
+        // Expose both Kafka ports:
+        // 9092 can be used inside Docker network (by the Schema Registry container)
+        .withExposedPorts(KafkaContainer.KAFKA_PORT, 9092)
+        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+
+    @Container
+    private final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer(kafka);
+
+    private AdminClient adminClient;
+    private KafkaProducer<String, GenericRecord> producer;
+
+    private ConnectRunner connectRunner;
+
+    @BeforeEach
+    void setUp() throws ExecutionException, InterruptedException {
+        testBucketAccessor.clear(gcsPrefix);
+
+        final Properties adminClientConfig = new Properties();
+        adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        adminClient = AdminClient.create(adminClientConfig);
+
+        final Map<String, Object> producerProps = new HashMap<>();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "io.confluent.kafka.serializers.KafkaAvroSerializer");
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "io.confluent.kafka.serializers.KafkaAvroSerializer");
+        producerProps.put("schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        producer = new KafkaProducer<>(producerProps);
+
+        final NewTopic newTopic0 = new NewTopic(TEST_TOPIC_0, 4, (short) 1);
+        final NewTopic newTopic1 = new NewTopic(TEST_TOPIC_1, 4, (short) 1);
+        adminClient.createTopics(Arrays.asList(newTopic0, newTopic1)).all().get();
+
+        connectRunner = new ConnectRunner(pluginDir, kafka.getBootstrapServers(), OFFSET_FLUSH_INTERVAL_MS);
+        connectRunner.start();
+    }
+
+    @AfterEach
+    final void tearDown() {
+        connectRunner.stop();
+        adminClient.close();
+        producer.close();
+
+        testBucketAccessor.clear(gcsPrefix);
+
+        connectRunner.awaitStop();
+    }
+
+    private String getTimestampBlobName(final int partition, final int startOffset) {
+        final ZonedDateTime time = ZonedDateTime.now(ZoneId.of("UTC"));
+        return String.format(
+                "%s%s-%d-%d-%s-%s-%s",
+                gcsPrefix,
+                TEST_TOPIC_0,
+                partition,
+                startOffset,
+                time.format(DateTimeFormatter.ofPattern("yyyy")),
+                time.format(DateTimeFormatter.ofPattern("MM")),
+                time.format(DateTimeFormatter.ofPattern("dd"))
+        );
+    }
+
+    @Test
+    final void jsonlOutput() throws ExecutionException, InterruptedException {
+        final Map<String, String> connectorConfig = basicConnectorConfig();
+        final String compression = "none";
+        connectorConfig.put("format.output.fields", "key,value");
+        connectorConfig.put("format.output.fields.value.encoding", "none");
+        connectorConfig.put("file.compression.type", compression);
+        connectorConfig.put("format.output.type", "jsonl");
+        connectRunner.createConnector(connectorConfig);
+
+        final Schema valueSchema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"value\","
+            + "\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}");
+
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        int cnt = 0;
+        for (int i = 0; i < 10; i++) {
+            for (int partition = 0; partition < 4; partition++) {
+                final String key = "key-" + cnt;
+                final GenericRecord value = new GenericData.Record(valueSchema);
+                value.put("name", "user-" + cnt);
+                cnt += 1;
+
+                sendFutures.add(sendMessageAsync(TEST_TOPIC_0, partition, key, value));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+
+        // TODO more robust way to detect that Connect finished processing
+        Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
+
+        final List<String> expectedBlobs = Arrays.asList(
+            getBlobName(0, 0, compression),
+            getBlobName(1, 0, compression),
+            getBlobName(2, 0, compression),
+            getBlobName(3, 0, compression));
+        assertIterableEquals(expectedBlobs, testBucketAccessor.getBlobNames(gcsPrefix));
+
+        final Map<String, List<String>> blobContents = new HashMap<>();
+        for (final String blobName : expectedBlobs) {
+            final List<String> items = new ArrayList<>(testBucketAccessor.readLines(blobName, compression));
+            blobContents.put(blobName, items);
+        }
+
+        cnt = 0;
+        for (int i = 0; i < 10; i++) {
+            for (int partition = 0; partition < 4; partition++) {
+                final String key = "key-" + cnt;
+                final String value = "{" + "\"name\":\"user-" + cnt + "\"}";
+                cnt += 1;
+
+                final String blobName = getBlobName(partition, 0, "none");
+                final String actualLine = blobContents.get(blobName).get(i);
+                final String expectedLine = "{\"value\":" + value + ",\"key\":\"" + key + "\"}";
+                assertEquals(expectedLine, actualLine);
+            }
+        }
+    }
+
+    private Future<RecordMetadata> sendMessageAsync(final String topicName,
+                                                    final int partition,
+                                                    final String key,
+                                                    final GenericRecord value) {
+        final ProducerRecord<String, GenericRecord> msg = new ProducerRecord<>(
+                topicName, partition, key, value);
+        return producer.send(msg);
+    }
+
+    private Map<String, String> basicConnectorConfig() {
+        final Map<String, String> config = new HashMap<>();
+        config.put("name", CONNECTOR_NAME);
+        config.put("connector.class", GcsSinkConnector.class.getName());
+        config.put("key.converter", "io.confluent.connect.avro.AvroConverter");
+        config.put("key.converter.schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        config.put("value.converter", "io.confluent.connect.avro.AvroConverter");
+        config.put("value.converter.schema.registry.url", schemaRegistry.getSchemaRegistryUrl());
+        config.put("tasks.max", "1");
+        if (gcsCredentialsPath != null) {
+            config.put("gcs.credentials.path", gcsCredentialsPath);
+        }
+        if (gcsCredentialsJson != null) {
+            config.put("gcs.credentials.json", gcsCredentialsJson);
+        }
+        config.put("gcs.bucket.name", testBucketName);
+        config.put("file.name.prefix", gcsPrefix);
+        config.put("topics", TEST_TOPIC_0 + "," + TEST_TOPIC_1);
+        return config;
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/SchemaRegistryContainer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/SchemaRegistryContainer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.Base58;
+
+final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+    public static final int SCHEMA_REGISTRY_PORT = 8081;
+
+    public SchemaRegistryContainer(final KafkaContainer kafka) {
+        this("5.2.1", kafka);
+    }
+
+    public SchemaRegistryContainer(final String confluentPlatformVersion, final KafkaContainer kafka) {
+        super("confluentinc/cp-schema-registry:" + confluentPlatformVersion);
+
+        dependsOn(kafka);
+        withNetwork(kafka.getNetwork());
+        withNetworkAliases("schema-registry-" + Base58.randomString(6));
+
+        withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS",
+            String.format("PLAINTEXT://%s:%s", kafka.getNetworkAliases().get(0), 9092));
+
+        withExposedPorts(SCHEMA_REGISTRY_PORT);
+        withEnv("SCHEMA_REGISTRY_HOST_NAME", "localhost");
+    }
+
+    public String getSchemaRegistryUrl() {
+        return String.format("http://%s:%s", getContainerIpAddress(), getMappedPort(SCHEMA_REGISTRY_PORT));
+    }
+}


### PR DESCRIPTION
This adds the integration test that checks the connector is able to consume Avro-encoded messages (with the appropriate converter) and output JSON lines.