### PR TITLE
Add Classic JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ There are two types of data format available:
     It contains one record per line and each line is a valid JSON object(`jsonl`)
  
     Configuration: ```format.output.type=jsonl```. 
+    
+ - Complex structure, where file is a valid JSON array of record objects. 
+  
+     Configuration: ```format.output.type=json```. 
 
 The connector can output the following fields from records into the
 output: the key, the value, the timestamp, and the offset. (The set of
@@ -235,6 +239,38 @@ OR
 
 ```
 { "key": "user1", "value": {"name": "John", "address": {"city": "London"}}, "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+```
+
+It is recommended to use
+- `org.apache.kafka.connect.storage.StringConverter`, 
+- `org.apache.kafka.connect.json.JsonConverter`, or
+- `io.confluent.connect.avro.AvroConverter`.
+ 
+as `key.converter` and/or `value.converter` to make output files human-readable.
+
+**NB!**
+
+ - The value of the `format.output.fields.value.encoding` property is ignored for this data format.
+ - Value/Key schema will not be presented in output file, even if `value.converter.schemas.enable` property is `true`.
+ But, it is still important to set this property correctly, so that connector could read records correctly. 
+ 
+#### JSON Format example
+
+For example, if we output `key,value,offset,timestamp`, an output file might look like:
+
+```
+[
+{ "key": "k1", "value": "v0", "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" },
+{ "key": "k2", "value": "v1", "offset": 1232156, "timestamp":"2020-01-01T00:00:05Z" }
+]
+```
+
+OR
+
+```
+[
+{ "key": "user1", "value": {"name": "John", "address": {"city": "London"}}, "offset": 1232155, "timestamp":"2020-01-01T00:00:01Z" }
+]
 ```
 
 It is recommended to use

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
     // Compatible with Kafka version:
     // https://docs.confluent.io/current/installation/versions-interoperability.html
     confluentPlatformVersion = "4.1.4"
-    aivenConnectCommonsVersion = "0.2.0"
+    aivenConnectCommonsVersion = "0.3.0"
     testcontainersVersion = "1.12.0"
 }
 

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -718,7 +718,7 @@ final class GcsSinkConfigTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"jsonl", "csv"})
+    @ValueSource(strings = {"jsonl", "json", "csv"})
     void supportedFormatTypeConfig(final String formatType) {
         final Map<String, String> properties = new HashMap<>();
         properties.put("gcs.bucket.name", "test-bucket");
@@ -743,7 +743,7 @@ final class GcsSinkConfigTest {
         );
         assertEquals(
             "Invalid value unknown for configuration format.output.type: "
-                + "supported values are: 'csv', 'jsonl'", t.getMessage());
+                + "supported values are: 'csv', 'json', 'jsonl'", t.getMessage());
 
     }
 


### PR DESCRIPTION
__WHY__:
Classic JSON support is another output format. Same format is supported in Confluent's GCS Sink. 

__WHAT__:
- Updated AivenCommon version. Main functionality is in a common module version 0.3.0
- Added support info to README
- Added tests to GCSTaskSink
