### PR TITLE
Fix ConfigDef validation YYYY in for file.name.template

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -69,7 +69,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
     private static final String DEFAULT_FILENAME_TEMPLATE = "{{topic}}-{{partition}}-{{start_offset}}";
 
     public static ConfigDef configDef() {
-        final ConfigDef configDef = new ConfigDef();
+        final GcsSinkConfigDef configDef = new GcsSinkConfigDef();
         addGcsConfigGroup(configDef);
         addFileConfigGroup(configDef);
         addFormatConfigGroup(configDef);
@@ -351,7 +351,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
         validate();
     }
 
-    private static Map<String, String> handleDeprecatedYyyyUppercase(final Map<String, String> properties) {
+    static Map<String, String> handleDeprecatedYyyyUppercase(final Map<String, String> properties) {
         if (properties.containsKey(FILE_NAME_TEMPLATE_CONFIG)) {
             final var result = new HashMap<>(properties);
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfigDef.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfigDef.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.gcs;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
+
+public class GcsSinkConfigDef extends ConfigDef {
+    @Override
+    public List<ConfigValue> validate(final Map<String, String> props) {
+        return super.validate(GcsSinkConfig.handleDeprecatedYyyyUppercase(props));
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -63,34 +63,19 @@ final class GcsSinkConfigTest {
         "",
         "{{topic}}", "{{partition}}", "{{start_offset}}",
         "{{topic}}-{{partition}}", "{{topic}}-{{start_offset}}", "{{partition}}-{{start_offset}}",
-        "{{topic}}-{{partition}}-{{start_offset}}",
-        "{{topic}}-{{partition}}-{{start_offset}}-{{key}}"
+        "{{topic}}-{{partition}}-{{start_offset}}-{{key}}",
+        "{{topic}}-{{partition}}-{{start_offset}}-{{unknown}}"
     })
-    final void incorrectFilenameTemplatesForKey(final String template) {
+    final void incorrectFilenameTemplates(final String template) {
         final Map<String, String> properties = Map.of(
-            GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, template
+            GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, template,
+            GcsSinkConfig.GCS_BUCKET_NAME_CONFIG, "some-bucket"
         );
-        assertThrows(
+        final var t = assertThrows(
             ConfigException.class,
             () -> new GcsSinkConfig(properties)
         );
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "",
-        "{{topic}}", "{{partition}}", "{{start_offset}}",
-        "{{topic}}-{{partition}}", "{{topic}}-{{start_offset}}", "{{partition}}-{{start_offset}}",
-        "{{topic}}-{{partition}}-{{start_offset}}-{{unknown}}"
-    })
-    final void incorrectFilenameTemplatesForTopicPartitionRecord(final String template) {
-        final Map<String, String> properties = Map.of(
-            GcsSinkConfig.FILE_NAME_TEMPLATE_CONFIG, template
-        );
-        assertThrows(
-            ConfigException.class,   
-            () -> new GcsSinkConfig(properties)
-        );
+        assertTrue(t.getMessage().startsWith("Invalid value "));
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -122,8 +122,7 @@ final class GcsSinkConfigTest {
             "gcs.bucket.name", "asdasd"
         );
 
-        // Commented out because this is actually a bug, will be fixed later.
-        // assertConfigDefValidationPasses(properties);
+        assertConfigDefValidationPasses(properties);
 
         final Template t = new GcsSinkConfig(properties).getFilenameTemplate();
         final String fileName = t.instance()


### PR DESCRIPTION
Earlier, `GcsSinkConfig.handleDeprecatedYyyyUppercase` was introduced to ensure backward compatibility with `YYYY` year formatting. However, this didn't work with `ConfigDef.validate`. This PR fixes this by introducing a custom `ConfigDef` class. Also, it improves testing in `GcsSinkConfigTest` to actually catch this bug. See individual commits for details.