### PR TITLE
Rename connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aiven Kafka GCS Connector
+# Kafka GCS Connector
 
 ![Pull Request Workflow](https://github.com/aiven/aiven-kafka-connect-gcs/workflows/Pull%20Request%20Workflow/badge.svg)
 


### PR DESCRIPTION
It's incorrect to say `Aiven Kafka GCS Connector` for the trademark reason.